### PR TITLE
[Feat] 개별 article 조회

### DIFF
--- a/src/main/java/com/example/Balenz/article/controller/ArticleController.java
+++ b/src/main/java/com/example/Balenz/article/controller/ArticleController.java
@@ -1,0 +1,25 @@
+package com.example.Balenz.article.controller;
+
+import com.example.Balenz.article.dto.ArticleDetailDto;
+import com.example.Balenz.article.service.ArticleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/article")
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    @GetMapping("/{articleId}")
+    public ResponseEntity<?> getArticleDetail(@PathVariable Long articleId) {
+        ArticleDetailDto articleDetail = articleService.getArticleDetail(articleId);
+        return ResponseEntity.ok().body(articleDetail);
+    }
+
+}

--- a/src/main/java/com/example/Balenz/article/dto/ArticleDetailDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/ArticleDetailDto.java
@@ -1,0 +1,46 @@
+package com.example.Balenz.article.dto;
+
+import com.example.Balenz.article.entity.FrameType;
+import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@JsonPropertyOrder({
+        "title",
+        "newsAgencyName",
+        "publishedAt",
+        "frameType",
+        "summary",
+        "articleUrl"
+})
+public class ArticleDetailDto {
+
+    private String title;
+
+    private String newsAgencyName;
+
+    private LocalDate publishedAt;
+
+    private FrameType frameType;
+
+    private String summary;
+
+    private String articleUrl;
+
+    private List<RelatedArticleDto> allRelatedArticles;
+
+    private List<RelatedArticleDto> valueRelatedArticles;
+
+    private List<RelatedArticleDto> neutralRelatedArticles;
+
+    private List<RelatedArticleDto> normRelatedArticles;
+
+    private List<ScopeSectionResponseDto.KeywordDto> hotKeywords;
+
+}

--- a/src/main/java/com/example/Balenz/article/dto/RelatedArticleDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/RelatedArticleDto.java
@@ -1,0 +1,25 @@
+package com.example.Balenz.article.dto;
+
+import com.example.Balenz.article.entity.FrameType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class RelatedArticleDto {
+
+    private Long id;
+
+    private String title;
+
+    private String newsAgencyName;
+
+    private LocalDate publishedAt;
+
+    private FrameType frameType;
+
+    private String summary;
+
+}

--- a/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,4 +23,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     """, nativeQuery = true)
     Optional<Article> findTopByKeyword_IdAndFrameTypeOrderByViewCountDesc(@Param("keywordId") Long keywordId,
                                                      @Param("frameType") String frameType);
+
+    List<Article> findTop4ByKeyword_IdAndFrameTypeAndIdNotOrderByPublishedAtDesc(Long keywordId, FrameType frameType, Long articleId);
 }

--- a/src/main/java/com/example/Balenz/article/service/ArticleService.java
+++ b/src/main/java/com/example/Balenz/article/service/ArticleService.java
@@ -1,0 +1,132 @@
+package com.example.Balenz.article.service;
+
+import com.example.Balenz.article.dto.ArticleDetailDto;
+import com.example.Balenz.article.dto.RelatedArticleDto;
+import com.example.Balenz.article.entity.Article;
+import com.example.Balenz.article.entity.FrameType;
+import com.example.Balenz.article.repository.ArticleRepository;
+import com.example.Balenz.global.exception.BaseException;
+import com.example.Balenz.global.exception.ErrorCode;
+import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
+import com.example.Balenz.keyword.entity.Keyword;
+import com.example.Balenz.keyword.repository.KeywordRepository;
+import com.example.Balenz.keyword.service.KeywordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+    private final KeywordRepository keywordRepository;
+    private final KeywordService keywordService;
+
+    public ArticleDetailDto getArticleDetail(Long id) {
+        Article article = articleRepository.findById(id).orElseThrow(
+                () -> new BaseException(ErrorCode.ARTICLE_NOT_FOUND, "해당 id의 기사를 찾을 수 없습니다."));
+
+        // 연관기사 조회 -> DTO 생성
+        Keyword keyword = article.getKeyword();
+        // 1차 - 각 FrameType별로 4개씩 조회
+        List<Article> strongValue = articleRepository.findTop4ByKeyword_IdAndFrameTypeAndIdNotOrderByPublishedAtDesc(keyword.getId(), FrameType.STRONG_VALUE, id);
+        List<Article> value = articleRepository.findTop4ByKeyword_IdAndFrameTypeAndIdNotOrderByPublishedAtDesc(keyword.getId(), FrameType.VALUE, id);
+        List<Article> neutral = articleRepository.findTop4ByKeyword_IdAndFrameTypeAndIdNotOrderByPublishedAtDesc(keyword.getId(), FrameType.NEUTRAL, id);
+        List<Article> norm = articleRepository.findTop4ByKeyword_IdAndFrameTypeAndIdNotOrderByPublishedAtDesc(keyword.getId(), FrameType.NORM, id);
+        List<Article> strongNorm = articleRepository.findTop4ByKeyword_IdAndFrameTypeAndIdNotOrderByPublishedAtDesc(keyword.getId(), FrameType.STRONG_NORM, id);
+
+        // VALUE
+        List<RelatedArticleDto> valueRelatedArticles = Stream
+                .concat(value.stream(), strongValue.stream())
+                .map(this::toRelatedArticleDto)
+                .collect(Collectors.toList());
+
+        // NORM
+        List<RelatedArticleDto> normRelatedArticles = Stream
+                .concat(norm.stream(), strongNorm.stream())
+                .map(this::toRelatedArticleDto)
+                .collect(Collectors.toList());
+
+        // NEUTRAL
+        List<RelatedArticleDto> neutralRelatedArticles = neutral.stream()
+                .map(this::toRelatedArticleDto).collect(Collectors.toList());
+
+        // 전체 - Value 3 Neutral 4 Norm 3 비율에 맞춰서 생성
+        List<RelatedArticleDto> allRelatedArticles = Stream.of(
+                pick(valueRelatedArticles, 3).stream(),
+                pick(neutralRelatedArticles, 4).stream(),
+                pick(normRelatedArticles, 3).stream()
+                ).flatMap(s -> s)
+                .collect(Collectors.toList());
+
+        if (allRelatedArticles.size() < 10) {
+            int remaining = allRelatedArticles.size() - 10;
+
+            // 전체 후보 풀 만들기
+            List<RelatedArticleDto> pool = Stream.of(
+                            valueRelatedArticles,
+                            neutralRelatedArticles,
+                            normRelatedArticles).flatMap(List::stream)
+                    .distinct()
+                    .collect(Collectors.toList());
+
+            // 이미 allRelatedArticles에 들어가있는 것 제외
+            pool.removeAll(allRelatedArticles);
+
+            // 부족한 만큼 추가
+            allRelatedArticles.addAll(pick(pool, remaining));
+        }
+
+        LocalDate serviceDate = keywordService.getCurrentServiceDate();
+        List<Keyword> keywords = keywordRepository.findTop6ByServiceDateOrderByViewCountDescIdDesc(serviceDate);
+        List<ScopeSectionResponseDto.KeywordDto> hotKeywords;
+        if (keywords.isEmpty()) {
+            hotKeywords = List.of();
+        } else {
+            hotKeywords = keywordService.getKeywordDtos(keywords);
+        }
+
+        return ArticleDetailDto.builder()
+                .title(article.getTitle())
+                .newsAgencyName(article.getNewsAgency().getName())
+                .publishedAt(article.getPublishedAt())
+                .frameType(article.getFrameType())
+                .summary(article.getSummary())
+                .articleUrl(article.getArticleUrl())
+                .valueRelatedArticles(shuffle(valueRelatedArticles))
+                .normRelatedArticles(shuffle(normRelatedArticles))
+                .neutralRelatedArticles(shuffle(neutralRelatedArticles))
+                .allRelatedArticles(allRelatedArticles)
+                .hotKeywords(hotKeywords).build();
+    }
+
+    private RelatedArticleDto toRelatedArticleDto(Article article) {
+        return RelatedArticleDto.builder()
+                .id(article.getId())
+                .title(article.getTitle())
+                .newsAgencyName(article.getNewsAgency().getName())
+                .publishedAt(article.getPublishedAt())
+                .frameType(article.getFrameType())
+                .summary(article.getSummary()).build();
+    }
+
+    private List<RelatedArticleDto> shuffle(List<RelatedArticleDto> list) {
+        Collections.shuffle(list);
+        return list;
+    }
+
+    /** 리스트 shuffle 후 count 개수만큼 뽑기 */
+    private List<RelatedArticleDto> pick(List<RelatedArticleDto> list, int count) {
+        List<RelatedArticleDto> shuffled = shuffle(list);
+
+        return shuffled.stream()
+                .limit(count).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/Balenz/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/Balenz/global/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
     // 소셜 로그인 관련
     INVALID_SOCIAL_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인입니다."),
 
+    // 기사 관련
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기사를 찾을 수 없습니다."),
+
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다.");
 

--- a/src/main/java/com/example/Balenz/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/example/Balenz/keyword/repository/KeywordRepository.java
@@ -14,4 +14,5 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     List<Keyword> findTop7ByCategoryAndServiceDateOrderByViewCountDescIdDesc(Category category, LocalDate serviceDate);
     List<Keyword> findTop7ByServiceDateOrderByViewCountDescIdDesc(LocalDate serviceDate);
     Optional<Keyword> findByNameAndCategoryAndServiceDate(String name, Category category, LocalDate serviceDate);
+    List<Keyword> findTop6ByServiceDateOrderByViewCountDescIdDesc(LocalDate serviceDate);
 }

--- a/src/main/java/com/example/Balenz/keyword/service/KeywordService.java
+++ b/src/main/java/com/example/Balenz/keyword/service/KeywordService.java
@@ -59,7 +59,17 @@ public class KeywordService {
 
         // 2-2. KeywordDto 리스트
         List<Keyword> subKeywords = keywords.stream().skip(1).toList();
-        List<ScopeSectionResponseDto.KeywordDto> keywordDtos = subKeywords.stream()
+        List<ScopeSectionResponseDto.KeywordDto> keywordDtos = getKeywordDtos(subKeywords);
+
+
+        return ScopeSectionResponseDto.builder()
+                .mainKeyword(mainKeywordDto)
+                .keywords(keywordDtos).build();
+    }
+
+    /** Keyword 리스트 -> KeywordDto 리스트 */
+    public List<ScopeSectionResponseDto.KeywordDto> getKeywordDtos(List<Keyword> keywords) {
+        return keywords.stream()
                 .map(k -> {
                     ScopeSectionResponseDto.ArticleCountDto countDto = getArticleCount(k.getId());
 
@@ -70,11 +80,6 @@ public class KeywordService {
                             .articleCount(countDto)
                             .dominantFrameType(getDominantArticleFrameType(countDto)).build();
                 }).toList();
-
-
-        return ScopeSectionResponseDto.builder()
-                .mainKeyword(mainKeywordDto)
-                .keywords(keywordDtos).build();
     }
 
     /** 키워드에 해당하는 프레임별 기사 수 */
@@ -130,7 +135,7 @@ public class KeywordService {
                 : now.toLocalDate();
     }
 
-    /** 데이터 사전 저장용 serviceDate 계산 (8시에 공개할 데이터 미리 저장) */
+    /** 데이터 사전 저장용 serviceDate (공개 대상 날짜) 계산 (8시에 공개할 데이터 미리 저장) */
     public LocalDate getPreparedServiceDate() {
         return LocalDate.now();
     }


### PR DESCRIPTION
closed #9 

- [x] 개별 기사 조회 구현

- /api/article/{articleId}로 개별 기사 조회 시 기사 세부 정보와 연관 기사 전체 (최대 10개), 프레임별 연관 기사 리스트, 인기 scope를 반환하도록 구현하였습니다.
- 기사 정보 반환 시 frameType (`STRONG_VALUE, VALUE, NEUTRAL, NORM, STRONG_NORM`)도 함께 반환하도록 구현하였습니다!