### PR TITLE
[Feat] 핫이슈 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/Balenz/article/controller/ArticleController.java
+++ b/src/main/java/com/example/Balenz/article/controller/ArticleController.java
@@ -2,6 +2,7 @@ package com.example.Balenz.article.controller;
 
 import com.example.Balenz.article.dto.ArticleDetailDto;
 import com.example.Balenz.article.service.ArticleService;
+import com.example.Balenz.global.response.BaseResponse;
 import com.example.Balenz.global.security.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,7 @@ public class ArticleController {
     public ResponseEntity<?> getArticleDetail(@PathVariable Long articleId,
                                               @AuthenticationPrincipal CustomPrincipal customPrincipal) {
         ArticleDetailDto articleDetail = articleService.getArticleDetail(articleId, customPrincipal.getId());
-        return ResponseEntity.ok().body(articleDetail);
+        return ResponseEntity.ok().body(BaseResponse.success(articleDetail));
     }
 
 }

--- a/src/main/java/com/example/Balenz/article/dto/ArticleDetailDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/ArticleDetailDto.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Data
 @Builder
 @JsonPropertyOrder({
+        "id",
         "title",
         "newsAgencyName",
         "publishedAt",
@@ -20,6 +21,8 @@ import java.util.List;
         "articleUrl"
 })
 public class ArticleDetailDto {
+
+    private Long id;
 
     private String title;
 

--- a/src/main/java/com/example/Balenz/article/dto/SimpleArticleDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/SimpleArticleDto.java
@@ -1,0 +1,19 @@
+package com.example.Balenz.article.dto;
+
+import com.example.Balenz.article.entity.FrameType;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SimpleArticleDto {
+
+    private Long id;
+
+    private String title;
+
+    private String newsAgencyName;
+
+    private FrameType frameType;
+
+}

--- a/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
@@ -26,4 +26,14 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
                                                      @Param("frameType") String frameType);
 
     List<Article> findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(Long keywordId, FrameType frameType);
+    @Query(value = """
+        SELECT *
+        FROM Article 
+        WHERE keyword_id = :keywordId
+          AND frame_type = :frameType
+        ORDER BY (value_user_view_count + neutral_user_view_count + norm_user_view_count) DESC, id ASC
+        LIMIT 2
+    """, nativeQuery = true)
+    List<Article> findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(@Param("keywordId") Long keywordId,
+                                                                          @Param("frameType") String frameType);
 }

--- a/src/main/java/com/example/Balenz/article/service/ArticleService.java
+++ b/src/main/java/com/example/Balenz/article/service/ArticleService.java
@@ -36,7 +36,6 @@ public class ArticleService {
     public ArticleDetailDto getArticleDetail(Long articleId, Long userId) {
         User user = authService.getCurrentUser(userId);
 
-
         Article article = articleRepository.findById(articleId).orElseThrow(
                 () -> new BaseException(ErrorCode.ARTICLE_NOT_FOUND, "해당 id의 기사를 찾을 수 없습니다."));
 
@@ -59,6 +58,7 @@ public class ArticleService {
         List<ScopeSectionResponseDto.KeywordDto> hotKeywords = keywordService.getHotKeywordDtos();
 
         return ArticleDetailDto.builder()
+                .id(article.getId())
                 .title(article.getTitle())
                 .newsAgencyName(article.getNewsAgency().getName())
                 .publishedAt(article.getPublishedAt())

--- a/src/main/java/com/example/Balenz/article/service/ArticleService.java
+++ b/src/main/java/com/example/Balenz/article/service/ArticleService.java
@@ -138,16 +138,13 @@ public class ArticleService {
                 .summary(article.getSummary()).build();
     }
 
-    private List<RelatedArticlesDto.RelatedArticleDto> shuffle(List<RelatedArticlesDto.RelatedArticleDto> list) {
-        Collections.shuffle(list);
-        return list;
-    }
-
     /** 리스트 shuffle 후 count 개수만큼 뽑기 */
     private List<RelatedArticlesDto.RelatedArticleDto> pick(List<RelatedArticlesDto.RelatedArticleDto> list, int count) {
         ArrayList<RelatedArticlesDto.RelatedArticleDto> copy = new ArrayList<>(list);
         Collections.shuffle(copy);
-        return copy;
+        return copy.stream()
+                .limit(count)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/Balenz/keyword/controller/KeywordController.java
+++ b/src/main/java/com/example/Balenz/keyword/controller/KeywordController.java
@@ -1,9 +1,11 @@
 package com.example.Balenz.keyword.controller;
 
 import com.example.Balenz.global.response.BaseResponse;
+import com.example.Balenz.keyword.dto.HotIssueDataDto;
 import com.example.Balenz.keyword.dto.KeywordDetailDto;
 import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
 import com.example.Balenz.keyword.entity.Category;
+import com.example.Balenz.keyword.service.HotKeywordService;
 import com.example.Balenz.keyword.service.KeywordDetailService;
 import com.example.Balenz.keyword.service.KeywordService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ public class KeywordController {
 
     private final KeywordService keywordService;
     private final KeywordDetailService keywordDetailService;
+    private final HotKeywordService hotKeywordService;
 
     @GetMapping("/ideology/keyword")
     public ResponseEntity<?> getScopeData(@RequestParam(required = false) Category category) {
@@ -28,6 +31,12 @@ public class KeywordController {
     public ResponseEntity<?> getKeywordDetail(@PathVariable Long keywordId) {
         KeywordDetailDto keywordDetail = keywordDetailService.getKeywordDetail(keywordId);
         return ResponseEntity.ok().body(BaseResponse.success(keywordDetail));
+    }
+
+    @GetMapping("/ideology/keyword/hot-issue")
+    public ResponseEntity<?> getHotIssueData() {
+        HotIssueDataDto hotIssueData = hotKeywordService.getHotIssueData();
+        return ResponseEntity.ok().body(BaseResponse.success(hotIssueData));
     }
 
 }

--- a/src/main/java/com/example/Balenz/keyword/controller/KeywordController.java
+++ b/src/main/java/com/example/Balenz/keyword/controller/KeywordController.java
@@ -1,5 +1,6 @@
 package com.example.Balenz.keyword.controller;
 
+import com.example.Balenz.global.response.BaseResponse;
 import com.example.Balenz.keyword.dto.KeywordDetailDto;
 import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
 import com.example.Balenz.keyword.entity.Category;
@@ -20,14 +21,13 @@ public class KeywordController {
     @GetMapping("/ideology/keyword")
     public ResponseEntity<?> getScopeData(@RequestParam(required = false) Category category) {
         ScopeSectionResponseDto scopeSectionData = keywordService.getScopeSectionData(category);
-        return ResponseEntity.ok()
-                .body(scopeSectionData);
+        return ResponseEntity.ok().body(BaseResponse.success(scopeSectionData));
     }
 
     @GetMapping("/keyword/{keywordId}")
     public ResponseEntity<?> getKeywordDetail(@PathVariable Long keywordId) {
         KeywordDetailDto keywordDetail = keywordDetailService.getKeywordDetail(keywordId);
-        return ResponseEntity.ok().body(keywordDetail);
+        return ResponseEntity.ok().body(BaseResponse.success(keywordDetail));
     }
 
 }

--- a/src/main/java/com/example/Balenz/keyword/dto/HotIssueDataDto.java
+++ b/src/main/java/com/example/Balenz/keyword/dto/HotIssueDataDto.java
@@ -1,0 +1,27 @@
+package com.example.Balenz.keyword.dto;
+
+import com.example.Balenz.article.dto.SimpleArticleDto;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class HotIssueDataDto {
+
+    List<KeywordAndArticleDto> keywordAndArticles;
+
+    @Data
+    @Builder
+    public static class KeywordAndArticleDto {
+
+        Long id;
+
+        String name;
+
+        List<SimpleArticleDto> articles;
+
+    }
+
+}

--- a/src/main/java/com/example/Balenz/keyword/service/HotKeywordService.java
+++ b/src/main/java/com/example/Balenz/keyword/service/HotKeywordService.java
@@ -1,0 +1,85 @@
+package com.example.Balenz.keyword.service;
+
+import com.example.Balenz.article.dto.SimpleArticleDto;
+import com.example.Balenz.article.entity.Article;
+import com.example.Balenz.article.entity.FrameType;
+import com.example.Balenz.article.repository.ArticleRepository;
+import com.example.Balenz.keyword.dto.HotIssueDataDto;
+import com.example.Balenz.keyword.entity.Keyword;
+import com.example.Balenz.keyword.repository.KeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class HotKeywordService {
+
+    private final KeywordRepository keywordRepository;
+    private final KeywordService keywordService;
+    private final ArticleRepository articleRepository;
+
+    /** 이념 관점 페이지에서 hot-issue 섹션 데이터 조회 */
+    public HotIssueDataDto getHotIssueData() {
+        // 1. 오늘 조회수가 가장 높은 키워드 조회
+        LocalDate serviceDate = keywordService.getCurrentServiceDate();
+        List<Keyword> keywords = keywordRepository.findTop6ByServiceDateOrderByViewCountDescIdDesc(serviceDate);
+
+        if (keywords.isEmpty()) {
+            return HotIssueDataDto.builder()
+                    .keywordAndArticles(List.of()).build();
+        }
+
+        List<HotIssueDataDto.KeywordAndArticleDto> keywordAndArticles = new ArrayList<>();
+
+        // 2. 각 키워드에서 인기있는 기사 2개 조회
+        for (Keyword keyword : keywords) {
+            List<Article> strongValue = articleRepository.findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(keyword.getId(), FrameType.STRONG_VALUE.name());
+            List<Article> value = articleRepository.findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(keyword.getId(), FrameType.VALUE.name());
+            List<Article> neutral = articleRepository.findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(keyword.getId(), FrameType.NEUTRAL.name());
+            List<Article> norm = articleRepository.findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(keyword.getId(), FrameType.NORM.name());
+            List<Article> strongNorm = articleRepository.findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(keyword.getId(), FrameType.STRONG_NORM.name());
+
+            // 각 프레임타입별로 기사 2개씩 조회 후 그 중 랜덤으로 2개 반환
+            List<Article> candidates
+                    = Stream.of(strongValue.stream(), value.stream(), neutral.stream(), norm.stream(), strongNorm.stream())
+                    .flatMap(s -> s).toList();
+
+            List<SimpleArticleDto> articles = pick(candidates, 2).stream()
+                    .map(this::toSimpleArticleDto).toList();
+
+            HotIssueDataDto.KeywordAndArticleDto keywordAndArticle = HotIssueDataDto.KeywordAndArticleDto.builder()
+                    .id(keyword.getId())
+                    .name(keyword.getName())
+                    .articles(articles).build();
+
+            keywordAndArticles.add(keywordAndArticle);
+        }
+
+        return HotIssueDataDto.builder()
+                .keywordAndArticles(keywordAndArticles).build();
+    }
+
+    private SimpleArticleDto toSimpleArticleDto(Article article) {
+        return SimpleArticleDto.builder()
+                .id(article.getId())
+                .title(article.getTitle())
+                .newsAgencyName(article.getNewsAgency().getName())
+                .frameType(article.getFrameType()).build();
+    }
+
+    private List<Article> pick(List<Article> list, int count) {
+        ArrayList<Article> copy = new ArrayList<>(list);
+        Collections.shuffle(copy);
+        return copy.stream()
+                .limit(count)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/Balenz/keyword/service/HotKeywordService.java
+++ b/src/main/java/com/example/Balenz/keyword/service/HotKeywordService.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -47,11 +48,23 @@ public class HotKeywordService {
             List<Article> strongNorm = articleRepository.findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(keyword.getId(), FrameType.STRONG_NORM.name());
 
             // 각 프레임타입별로 기사 2개씩 조회 후 그 중 랜덤으로 2개 반환
-            List<Article> candidates
-                    = Stream.of(strongValue.stream(), value.stream(), neutral.stream(), norm.stream(), strongNorm.stream())
-                    .flatMap(s -> s).toList();
+            List<Article> valueCandidates = Stream.concat(strongValue.stream(), value.stream()).toList();
+            List<Article> normCandidates = Stream.concat(strongNorm.stream(), norm.stream()).toList();
 
-            List<SimpleArticleDto> articles = pick(candidates, 2).stream()
+            // 3. value에서 1개, norm에서 1개 선택
+            List<Article> selectedArticles = new ArrayList<>();
+
+            pickOne(valueCandidates).ifPresent(selectedArticles::add);
+            pickOne(normCandidates).ifPresent(selectedArticles::add);
+
+            // 4. 선택된 기사 개수 합이 2가 아닌 경우 남은 건 neutral에서
+            fillRemaining(selectedArticles, neutral);
+
+            // 5. 그래도 2개가 안되는 경우 value나 neutral에서 추가
+            fillRemaining(selectedArticles, valueCandidates);
+            fillRemaining(selectedArticles, normCandidates);
+
+            List<SimpleArticleDto> articles = selectedArticles.stream()
                     .map(this::toSimpleArticleDto).toList();
 
             HotIssueDataDto.KeywordAndArticleDto keywordAndArticle = HotIssueDataDto.KeywordAndArticleDto.builder()
@@ -74,12 +87,30 @@ public class HotKeywordService {
                 .frameType(article.getFrameType()).build();
     }
 
-    private List<Article> pick(List<Article> list, int count) {
-        ArrayList<Article> copy = new ArrayList<>(list);
+    private Optional<Article> pickOne(List<Article> articles) {
+        return pick(articles, 1).stream().findFirst();
+    }
+
+    private List<Article> pick(List<Article> articles, int count) {
+        ArrayList<Article> copy = new ArrayList<>(articles);
         Collections.shuffle(copy);
         return copy.stream()
                 .limit(count)
                 .collect(Collectors.toList());
+    }
+
+    /** 선택된 기사 개수가 2 미만일 경우 채우기 */
+    private void fillRemaining(List<Article> selected, List<Article> source) {
+        if (selected.size() >= 2) return;
+
+        List<Long> selectedIds = selected.stream()
+                .map(Article::getId).toList();
+
+        List<Article> candidates = source.stream()
+                .filter(a -> !selectedIds.contains(a.getId())) // 중복 방지
+                .toList();
+
+        selected.addAll(pick(candidates, 2 - selectedIds.size()));
     }
 
 }


### PR DESCRIPTION
## ✅ 관련 이슈
closed #16 

## ✨ 작업 내용
이념 관점 - 핫이슈 섹션 데이터 조회 기능 구현
오늘 기준으로 조회수가 가장 높은 키워드 6개 조회
-> 각 키워드별로 모든 프레임타입별 조회수 높은 기사 2개씩 조회 = 최대 10개
-> 그 중 strongValue/value에서 1개, strongNorm/norm에서 1개 선택
-> 만약 선택된 기사 총합이 2개가 되지 않는 경우 neutral에서 남은 개수만큼 선택
-> 그래도 2개가 되지 않는 경우 strongValue/value와 strongNorm/norm에서 남은 개수만큼 추가 선택

## 📸 스크린샷


## 🗨️ 참고 사항
