### PR TITLE
[Feat] 기사 스크랩 기능 구현

### DIFF
--- a/src/main/java/com/example/Balenz/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/Balenz/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     // 기사 관련
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기사를 찾을 수 없습니다."),
+    ARTICLE_SCRAP_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 기사 스크랩이 존재합니다."),
 
     // 키워드 관련
     KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 키워드를 찾을 수 없습니다."),

--- a/src/main/java/com/example/Balenz/scrap/controller/ArticleScrapController.java
+++ b/src/main/java/com/example/Balenz/scrap/controller/ArticleScrapController.java
@@ -1,0 +1,28 @@
+package com.example.Balenz.scrap.controller;
+
+import com.example.Balenz.global.response.BaseResponse;
+import com.example.Balenz.global.security.CustomPrincipal;
+import com.example.Balenz.scrap.service.ArticleScrapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ArticleScrapController {
+
+    private final ArticleScrapService articleScrapService;
+
+    @PostMapping("/article/{articleId}/scrap")
+    public ResponseEntity<?> scrapArticle(@PathVariable Long articleId,
+                                          @AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        articleScrapService.scrapArticle(articleId, customPrincipal.getId());
+        return ResponseEntity.ok().body(BaseResponse.success(null));
+    }
+
+}

--- a/src/main/java/com/example/Balenz/scrap/entity/UserArticleScrap.java
+++ b/src/main/java/com/example/Balenz/scrap/entity/UserArticleScrap.java
@@ -1,0 +1,39 @@
+package com.example.Balenz.scrap.entity;
+
+import com.example.Balenz.article.entity.Article;
+import com.example.Balenz.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"user_id", "article_id"}
+        )
+)
+public class UserArticleScrap {
+
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @Builder
+    public UserArticleScrap(User user, Article article) {
+        this.user = user;
+        this.article = article;
+    }
+
+}

--- a/src/main/java/com/example/Balenz/scrap/repository/UserArticleScrapRepository.java
+++ b/src/main/java/com/example/Balenz/scrap/repository/UserArticleScrapRepository.java
@@ -1,0 +1,10 @@
+package com.example.Balenz.scrap.repository;
+
+import com.example.Balenz.scrap.entity.UserArticleScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserArticleScrapRepository extends JpaRepository<UserArticleScrap, Long> {
+    boolean existsByUser_IdAndArticle_Id(Long userId, Long articleId);
+}

--- a/src/main/java/com/example/Balenz/scrap/service/ArticleScrapService.java
+++ b/src/main/java/com/example/Balenz/scrap/service/ArticleScrapService.java
@@ -1,0 +1,40 @@
+package com.example.Balenz.scrap.service;
+
+import com.example.Balenz.article.entity.Article;
+import com.example.Balenz.article.repository.ArticleRepository;
+import com.example.Balenz.global.exception.BaseException;
+import com.example.Balenz.global.exception.ErrorCode;
+import com.example.Balenz.scrap.entity.UserArticleScrap;
+import com.example.Balenz.scrap.repository.UserArticleScrapRepository;
+import com.example.Balenz.user.entity.User;
+import com.example.Balenz.user.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleScrapService {
+
+    private final ArticleRepository articleRepository;
+    private final AuthService authService;
+    private final UserArticleScrapRepository userArticleScrapRepository;
+
+    @Transactional
+    public void scrapArticle(Long articleId, Long userId) {
+        User user = authService.getCurrentUser(userId);
+
+        Article article = articleRepository.findById(articleId).orElseThrow(
+                () -> new BaseException(ErrorCode.ARTICLE_NOT_FOUND, "해당 id의 기사를 찾을 수 없습니다."));
+
+        if (userArticleScrapRepository.existsByUser_IdAndArticle_Id(userId, articleId)) {
+            throw new BaseException(ErrorCode.ARTICLE_SCRAP_ALREADY_EXISTS, "이미 스크랩한 기사입니다.");
+        }
+
+        userArticleScrapRepository.save(
+                UserArticleScrap.builder()
+                        .user(user)
+                        .article(article).build());
+    }
+
+}


### PR DESCRIPTION
## ✅ 관련 이슈
closed #18

## ✨ 작업 내용
- 기사 스크랩 기능 구현
동일한 기사 다시 스크랩 시 `ARTICLE_SCRAP_ALREADY_EXISTS`, 409 상태코드 반환
경로변수로 전달한 id의 기사가 존재하지 않는 경우 `ARTICLE_NOT_FOUND`, 404 상태코드 반환

## 📸 스크린샷


## 🗨️ 참고 사항
