### PR TITLE
[Feat] 관심 기사 섹션 데이터 조회

### DIFF
--- a/src/main/java/com/example/Balenz/article/controller/ArticleController.java
+++ b/src/main/java/com/example/Balenz/article/controller/ArticleController.java
@@ -1,6 +1,8 @@
 package com.example.Balenz.article.controller;
 
 import com.example.Balenz.article.dto.ArticleDetailDto;
+import com.example.Balenz.article.dto.ArticlesByIdeologyInterestDto;
+import com.example.Balenz.article.service.ArticleDetailService;
 import com.example.Balenz.article.service.ArticleService;
 import com.example.Balenz.global.response.BaseResponse;
 import com.example.Balenz.global.security.CustomPrincipal;
@@ -14,16 +16,23 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/article")
+@RequestMapping("/api")
 public class ArticleController {
 
+    private final ArticleDetailService articleDetailService;
     private final ArticleService articleService;
 
-    @GetMapping("/{articleId}")
+    @GetMapping("/article/{articleId}")
     public ResponseEntity<?> getArticleDetail(@PathVariable Long articleId,
                                               @AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        ArticleDetailDto articleDetail = articleService.getArticleDetail(articleId, customPrincipal.getId());
+        ArticleDetailDto articleDetail = articleDetailService.getArticleDetail(articleId, customPrincipal.getId());
         return ResponseEntity.ok().body(BaseResponse.success(articleDetail));
+    }
+
+    @GetMapping("/ideology/article/interest")
+    public ResponseEntity<?> getArticlesByIdeologyInterest() {
+        ArticlesByIdeologyInterestDto articlesByIdeologyInterest = articleService.getArticlesByIdeologyInterest();
+        return ResponseEntity.ok().body(BaseResponse.success(articlesByIdeologyInterest));
     }
 
 }

--- a/src/main/java/com/example/Balenz/article/dto/ArticlesByIdeologyInterestDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/ArticlesByIdeologyInterestDto.java
@@ -1,0 +1,16 @@
+package com.example.Balenz.article.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ArticlesByIdeologyInterestDto {
+
+    private List<SimpleArticleDto> valueInterestArticles;
+
+    private List<SimpleArticleDto> normInterestArticles;
+
+}

--- a/src/main/java/com/example/Balenz/article/dto/SimpleArticleDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/SimpleArticleDto.java
@@ -16,4 +16,6 @@ public class SimpleArticleDto {
 
     private FrameType frameType;
 
+    private String imageUrl;
+
 }

--- a/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,4 +37,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     """, nativeQuery = true)
     List<Article> findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(@Param("keywordId") Long keywordId,
                                                                           @Param("frameType") String frameType);
+    List<Article> findTop8ByKeyword_ServiceDateOrderByValueUserViewCountDesc(LocalDate serviceDate);
+    List<Article> findTop8ByKeyword_ServiceDateOrderByNormUserViewCountDesc(LocalDate serviceDate);
 }

--- a/src/main/java/com/example/Balenz/article/service/ArticleDetailService.java
+++ b/src/main/java/com/example/Balenz/article/service/ArticleDetailService.java
@@ -1,0 +1,150 @@
+package com.example.Balenz.article.service;
+
+import com.example.Balenz.article.dto.ArticleDetailDto;
+import com.example.Balenz.article.dto.RelatedArticlesDto;
+import com.example.Balenz.article.entity.Article;
+import com.example.Balenz.article.entity.FrameType;
+import com.example.Balenz.article.repository.ArticleRepository;
+import com.example.Balenz.global.exception.BaseException;
+import com.example.Balenz.global.exception.ErrorCode;
+import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
+import com.example.Balenz.keyword.entity.Keyword;
+import com.example.Balenz.keyword.service.KeywordService;
+import com.example.Balenz.user.entity.Ideology;
+import com.example.Balenz.user.entity.User;
+import com.example.Balenz.user.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleDetailService {
+
+    private final ArticleRepository articleRepository;
+    private final KeywordService keywordService;
+    private final AuthService authService;
+
+    @Transactional
+    public ArticleDetailDto getArticleDetail(Long articleId, Long userId) {
+        User user = authService.getCurrentUser(userId);
+
+        Article article = articleRepository.findById(articleId).orElseThrow(
+                () -> new BaseException(ErrorCode.ARTICLE_NOT_FOUND, "해당 id의 기사를 찾을 수 없습니다."));
+
+        // user의 ideology에 따라 기사 조회수 증가
+        Ideology ideology = user.getIdeology();
+        if (ideology != null) {
+            switch (ideology) {
+                case VALUE -> article.increaseValueUserViewCount();
+                case NEUTRAL -> article.increaseNeutralUserViewCount();
+                case NORM -> article.increaseNormUserViewCount();
+            }
+        }
+
+        // 연관기사 조회 -> DTO 생성
+        Keyword keyword = article.getKeyword();
+        Set<Long> excludeArticleIds = Set.of(articleId);
+        RelatedArticlesDto relatedArticlesDto = getRelatedArticlesDto(keyword.getId(), excludeArticleIds);
+
+        // 인기 scope 조회
+        List<ScopeSectionResponseDto.KeywordDto> hotKeywords = keywordService.getHotKeywordDtos();
+
+        return ArticleDetailDto.builder()
+                .id(article.getId())
+                .title(article.getTitle())
+                .newsAgencyName(article.getNewsAgency().getName())
+                .publishedAt(article.getPublishedAt())
+                .frameType(article.getFrameType())
+                .summary(article.getSummary())
+                .articleUrl(article.getArticleUrl())
+                .relatedArticles(relatedArticlesDto)
+                .hotKeywords(hotKeywords).build();
+    }
+
+    public RelatedArticlesDto getRelatedArticlesDto(Long keywordId, Set<Long> excludeArticleIds) {
+        List<Article> strongValue = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.STRONG_VALUE);
+        List<Article> value = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.VALUE);
+        List<Article> neutral = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.NEUTRAL);
+        List<Article> norm = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.NORM);
+        List<Article> strongNorm = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.STRONG_NORM);
+
+        List<RelatedArticlesDto.RelatedArticleDto> valueRelatedArticles = Stream
+                .concat(value.stream(), strongValue.stream())
+                .filter(article -> !excludeArticleIds.contains(article.getId()))
+                .map(this::toRelatedArticleDto)
+                .collect(Collectors.toList());
+
+        List<RelatedArticlesDto.RelatedArticleDto> normRelatedArticles = Stream
+                .concat(norm.stream(), strongNorm.stream())
+                .filter(article -> !excludeArticleIds.contains(article.getId()))
+                .map(this::toRelatedArticleDto)
+                .collect(Collectors.toList());
+
+        List<RelatedArticlesDto.RelatedArticleDto> neutralRelatedArticles = neutral.stream()
+                .filter(article -> !excludeArticleIds.contains(article.getId()))
+                .map(this::toRelatedArticleDto).collect(Collectors.toList());
+
+        // 전체 - Value 3 Neutral 4 Norm 3 비율에 맞춰서 생성
+        List<RelatedArticlesDto.RelatedArticleDto> allRelatedArticles = Stream.of(
+                pick(valueRelatedArticles, 3).stream(),
+                pick(neutralRelatedArticles, 4).stream(),
+                pick(normRelatedArticles, 3).stream()
+                ).flatMap(s -> s)
+                .collect(Collectors.toList());
+
+        if (allRelatedArticles.size() < 10) {
+            int remaining = 10 - allRelatedArticles.size();
+
+            // 전체 후보 풀 만들기
+            List<RelatedArticlesDto.RelatedArticleDto> pool = Stream.of(
+                            valueRelatedArticles,
+                            neutralRelatedArticles,
+                            normRelatedArticles)
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+
+            // 이미 allRelatedArticles에 들어가있는 것 제외
+            pool.removeIf(
+                    a -> allRelatedArticles.stream()
+                            .anyMatch(s -> s.getId().equals(a.getId()))
+            );
+
+            // 부족한 만큼 추가
+            allRelatedArticles.addAll(pick(pool, remaining));
+        }
+
+        return RelatedArticlesDto.builder()
+                .all(allRelatedArticles)
+                .value(valueRelatedArticles)
+                .neutral(neutralRelatedArticles)
+                .norm(normRelatedArticles).build();
+    }
+
+    public RelatedArticlesDto.RelatedArticleDto toRelatedArticleDto(Article article) {
+        return RelatedArticlesDto.RelatedArticleDto.builder()
+                .id(article.getId())
+                .title(article.getTitle())
+                .newsAgencyName(article.getNewsAgency().getName())
+                .publishedAt(article.getPublishedAt())
+                .frameType(article.getFrameType())
+                .summary(article.getSummary()).build();
+    }
+
+    /** 리스트 shuffle 후 count 개수만큼 뽑기 */
+    private List<RelatedArticlesDto.RelatedArticleDto> pick(List<RelatedArticlesDto.RelatedArticleDto> list, int count) {
+        ArrayList<RelatedArticlesDto.RelatedArticleDto> copy = new ArrayList<>(list);
+        Collections.shuffle(copy);
+        return copy.stream()
+                .limit(count)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/Balenz/article/service/ArticleService.java
+++ b/src/main/java/com/example/Balenz/article/service/ArticleService.java
@@ -1,28 +1,16 @@
 package com.example.Balenz.article.service;
 
-import com.example.Balenz.article.dto.ArticleDetailDto;
-import com.example.Balenz.article.dto.RelatedArticlesDto;
+import com.example.Balenz.article.dto.ArticlesByIdeologyInterestDto;
+import com.example.Balenz.article.dto.SimpleArticleDto;
 import com.example.Balenz.article.entity.Article;
-import com.example.Balenz.article.entity.FrameType;
 import com.example.Balenz.article.repository.ArticleRepository;
-import com.example.Balenz.global.exception.BaseException;
-import com.example.Balenz.global.exception.ErrorCode;
-import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
-import com.example.Balenz.keyword.entity.Keyword;
+import com.example.Balenz.keyword.service.HotKeywordService;
 import com.example.Balenz.keyword.service.KeywordService;
-import com.example.Balenz.user.entity.Ideology;
-import com.example.Balenz.user.entity.User;
-import com.example.Balenz.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -30,121 +18,32 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
     private final KeywordService keywordService;
-    private final AuthService authService;
+    private final HotKeywordService hotKeywordService;
 
-    @Transactional
-    public ArticleDetailDto getArticleDetail(Long articleId, Long userId) {
-        User user = authService.getCurrentUser(userId);
+    public ArticlesByIdeologyInterestDto getArticlesByIdeologyInterest() {
+        LocalDate serviceDate = keywordService.getCurrentServiceDate();
+        List<Article> top8ValueUserViewCountArticles = articleRepository.findTop8ByKeyword_ServiceDateOrderByValueUserViewCountDesc(serviceDate);
+        List<Article> top8NormUserViewCountArticles = articleRepository.findTop8ByKeyword_ServiceDateOrderByNormUserViewCountDesc(serviceDate);
 
-        Article article = articleRepository.findById(articleId).orElseThrow(
-                () -> new BaseException(ErrorCode.ARTICLE_NOT_FOUND, "해당 id의 기사를 찾을 수 없습니다."));
+        List<SimpleArticleDto> valueInterestArticles = top8ValueUserViewCountArticles.stream()
+                .map(this::toSimpleArticleDtoWithoutImage)
+                .toList();
+        List<SimpleArticleDto> normInterestArticles = top8NormUserViewCountArticles.stream()
+                .map(this::toSimpleArticleDtoWithoutImage)
+                .toList();
 
-        // user의 ideology에 따라 기사 조회수 증가
-        Ideology ideology = user.getIdeology();
-        if (ideology != null) {
-            switch (ideology) {
-                case VALUE -> article.increaseValueUserViewCount();
-                case NEUTRAL -> article.increaseNeutralUserViewCount();
-                case NORM -> article.increaseNormUserViewCount();
-            }
-        }
+        return ArticlesByIdeologyInterestDto.builder()
+                .valueInterestArticles(valueInterestArticles)
+                .normInterestArticles(normInterestArticles).build();
+    }
 
-        // 연관기사 조회 -> DTO 생성
-        Keyword keyword = article.getKeyword();
-        Set<Long> excludeArticleIds = Set.of(articleId);
-        RelatedArticlesDto relatedArticlesDto = getRelatedArticlesDto(keyword.getId(), excludeArticleIds);
-
-        // 인기 scope 조회
-        List<ScopeSectionResponseDto.KeywordDto> hotKeywords = keywordService.getHotKeywordDtos();
-
-        return ArticleDetailDto.builder()
+    private SimpleArticleDto toSimpleArticleDtoWithoutImage(Article article) {
+        return SimpleArticleDto.builder()
                 .id(article.getId())
                 .title(article.getTitle())
                 .newsAgencyName(article.getNewsAgency().getName())
-                .publishedAt(article.getPublishedAt())
                 .frameType(article.getFrameType())
-                .summary(article.getSummary())
-                .articleUrl(article.getArticleUrl())
-                .relatedArticles(relatedArticlesDto)
-                .hotKeywords(hotKeywords).build();
-    }
-
-    public RelatedArticlesDto getRelatedArticlesDto(Long keywordId, Set<Long> excludeArticleIds) {
-        List<Article> strongValue = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.STRONG_VALUE);
-        List<Article> value = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.VALUE);
-        List<Article> neutral = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.NEUTRAL);
-        List<Article> norm = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.NORM);
-        List<Article> strongNorm = articleRepository.findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(keywordId, FrameType.STRONG_NORM);
-
-        List<RelatedArticlesDto.RelatedArticleDto> valueRelatedArticles = Stream
-                .concat(value.stream(), strongValue.stream())
-                .filter(article -> !excludeArticleIds.contains(article.getId()))
-                .map(this::toRelatedArticleDto)
-                .collect(Collectors.toList());
-
-        List<RelatedArticlesDto.RelatedArticleDto> normRelatedArticles = Stream
-                .concat(norm.stream(), strongNorm.stream())
-                .filter(article -> !excludeArticleIds.contains(article.getId()))
-                .map(this::toRelatedArticleDto)
-                .collect(Collectors.toList());
-
-        List<RelatedArticlesDto.RelatedArticleDto> neutralRelatedArticles = neutral.stream()
-                .filter(article -> !excludeArticleIds.contains(article.getId()))
-                .map(this::toRelatedArticleDto).collect(Collectors.toList());
-
-        // 전체 - Value 3 Neutral 4 Norm 3 비율에 맞춰서 생성
-        List<RelatedArticlesDto.RelatedArticleDto> allRelatedArticles = Stream.of(
-                pick(valueRelatedArticles, 3).stream(),
-                pick(neutralRelatedArticles, 4).stream(),
-                pick(normRelatedArticles, 3).stream()
-                ).flatMap(s -> s)
-                .collect(Collectors.toList());
-
-        if (allRelatedArticles.size() < 10) {
-            int remaining = 10 - allRelatedArticles.size();
-
-            // 전체 후보 풀 만들기
-            List<RelatedArticlesDto.RelatedArticleDto> pool = Stream.of(
-                            valueRelatedArticles,
-                            neutralRelatedArticles,
-                            normRelatedArticles)
-                    .flatMap(List::stream)
-                    .collect(Collectors.toList());
-
-            // 이미 allRelatedArticles에 들어가있는 것 제외
-            pool.removeIf(
-                    a -> allRelatedArticles.stream()
-                            .anyMatch(s -> s.getId().equals(a.getId()))
-            );
-
-            // 부족한 만큼 추가
-            allRelatedArticles.addAll(pick(pool, remaining));
-        }
-
-        return RelatedArticlesDto.builder()
-                .all(allRelatedArticles)
-                .value(valueRelatedArticles)
-                .neutral(neutralRelatedArticles)
-                .norm(normRelatedArticles).build();
-    }
-
-    public RelatedArticlesDto.RelatedArticleDto toRelatedArticleDto(Article article) {
-        return RelatedArticlesDto.RelatedArticleDto.builder()
-                .id(article.getId())
-                .title(article.getTitle())
-                .newsAgencyName(article.getNewsAgency().getName())
-                .publishedAt(article.getPublishedAt())
-                .frameType(article.getFrameType())
-                .summary(article.getSummary()).build();
-    }
-
-    /** 리스트 shuffle 후 count 개수만큼 뽑기 */
-    private List<RelatedArticlesDto.RelatedArticleDto> pick(List<RelatedArticlesDto.RelatedArticleDto> list, int count) {
-        ArrayList<RelatedArticlesDto.RelatedArticleDto> copy = new ArrayList<>(list);
-        Collections.shuffle(copy);
-        return copy.stream()
-                .limit(count)
-                .collect(Collectors.toList());
+                .imageUrl(null).build();
     }
 
 }

--- a/src/main/java/com/example/Balenz/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/Balenz/global/security/SecurityConfig.java
@@ -48,9 +48,9 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/article/*/scrap", "/api/keyword/*/scrap").authenticated()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated())
+                        .anyRequest().permitAll())
 
                 .oauth2Login(oauth -> oauth
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))

--- a/src/main/java/com/example/Balenz/keyword/service/HotKeywordService.java
+++ b/src/main/java/com/example/Balenz/keyword/service/HotKeywordService.java
@@ -84,7 +84,8 @@ public class HotKeywordService {
                 .id(article.getId())
                 .title(article.getTitle())
                 .newsAgencyName(article.getNewsAgency().getName())
-                .frameType(article.getFrameType()).build();
+                .frameType(article.getFrameType())
+                .imageUrl(article.getImageUrl()).build();
     }
 
     private Optional<Article> pickOne(List<Article> articles) {

--- a/src/main/java/com/example/Balenz/keyword/service/KeywordDetailService.java
+++ b/src/main/java/com/example/Balenz/keyword/service/KeywordDetailService.java
@@ -4,7 +4,7 @@ import com.example.Balenz.article.dto.RelatedArticlesDto;
 import com.example.Balenz.article.entity.Article;
 import com.example.Balenz.article.entity.FrameType;
 import com.example.Balenz.article.repository.ArticleRepository;
-import com.example.Balenz.article.service.ArticleService;
+import com.example.Balenz.article.service.ArticleDetailService;
 import com.example.Balenz.global.exception.BaseException;
 import com.example.Balenz.global.exception.ErrorCode;
 import com.example.Balenz.keyword.dto.KeywordDetailDto;
@@ -29,7 +29,7 @@ public class KeywordDetailService {
     private final KeywordRepository keywordRepository;
     private final ArticleRepository articleRepository;
     private final KeywordService keywordService;
-    private final ArticleService articleService;
+    private final ArticleDetailService articleDetailService;
 
     @Transactional
     public KeywordDetailDto getKeywordDetail(Long id) {
@@ -52,7 +52,7 @@ public class KeywordDetailService {
 
         // 연관기사 조회 (메인 기사는 제외)
         Set<Long> mainArticleIds = getMainArticleIds(mainArticles);
-        RelatedArticlesDto relatedArticlesDto = articleService.getRelatedArticlesDto(id, mainArticleIds);
+        RelatedArticlesDto relatedArticlesDto = articleDetailService.getRelatedArticlesDto(id, mainArticleIds);
 
         return KeywordDetailDto.builder()
                 .id(id)
@@ -90,7 +90,7 @@ public class KeywordDetailService {
         // NEUTRAL 프레임 메인 기사
         RelatedArticlesDto.RelatedArticleDto mainNeutralDto = null;
         if (mainNeutralArticle != null) {
-            mainNeutralDto = articleService.toRelatedArticleDto(mainNeutralArticle);
+            mainNeutralDto = articleDetailService.toRelatedArticleDto(mainNeutralArticle);
         }
 
         // NORM 프레임 (STRONG_NORM / NORM) 메인 기사
@@ -106,14 +106,14 @@ public class KeywordDetailService {
     private RelatedArticlesDto.RelatedArticleDto getMainArticle(Article article1, Article article2) {
         if (article1 != null && article2 != null) { // 둘 다 null이 아니면 둘 중 조회수 더 많은 것이 메인
             if (article1.getTotalViewCount() > article2.getTotalViewCount()) {
-                return articleService.toRelatedArticleDto(article1);
+                return articleDetailService.toRelatedArticleDto(article1);
             } else {
-                return articleService.toRelatedArticleDto(article2);
+                return articleDetailService.toRelatedArticleDto(article2);
             }
         } else if (article1 != null) {
-            return articleService.toRelatedArticleDto(article1);
+            return articleDetailService.toRelatedArticleDto(article1);
         } else if (article2 != null) {
-            return articleService.toRelatedArticleDto(article2);
+            return articleDetailService.toRelatedArticleDto(article2);
         }
         return null;
     }


### PR DESCRIPTION
## ✅ 관련 이슈
closed #20 

## ✨ 작업 내용
- 스크랩과 어드민용 API를 제외한 모든 API의 접근 권한을 permitAll()로 설정
- 관심 기사 섹션 데이터 조회 기능 구현
오늘의 기사들 중 valueUserViewCount와 normUserViewCount가 높은 순서대로 각각 8개씩 SimpleArticleDto로 매핑하여 반환하도록 함

## 📸 스크린샷


## 🗨️ 참고 사항
