### PR TITLE
[Feat] 이념별 기사 섹션 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/Balenz/article/controller/ArticleController.java
+++ b/src/main/java/com/example/Balenz/article/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package com.example.Balenz.article.controller;
 
 import com.example.Balenz.article.dto.ArticleDetailDto;
+import com.example.Balenz.article.dto.ArticlesByIdeologyDto;
 import com.example.Balenz.article.dto.ArticlesByIdeologyInterestDto;
 import com.example.Balenz.article.service.ArticleDetailService;
 import com.example.Balenz.article.service.ArticleService;
@@ -34,6 +35,11 @@ public class ArticleController {
     public ResponseEntity<?> getArticlesByIdeologyInterest() {
         ArticlesByIdeologyInterestDto articlesByIdeologyInterest = articleService.getArticlesByIdeologyInterest();
         return ResponseEntity.ok().body(BaseResponse.success(articlesByIdeologyInterest));
+    }
+    @GetMapping("/ideology/article/by-ideology")
+    public ResponseEntity<?> getArticlesByIdeology() {
+        ArticlesByIdeologyDto articlesByIdeology = articleService.getArticlesByIdeology();
+        return ResponseEntity.ok().body(BaseResponse.success(articlesByIdeology));
     }
 
 }

--- a/src/main/java/com/example/Balenz/article/dto/ArticlesByIdeologyDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/ArticlesByIdeologyDto.java
@@ -1,0 +1,18 @@
+package com.example.Balenz.article.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ArticlesByIdeologyDto {
+
+    private List<SimpleArticleDto> value;
+
+    private List<SimpleArticleDto> neutral;
+
+    private List<SimpleArticleDto> norm;
+
+}

--- a/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.example.Balenz.article.repository;
 
 import com.example.Balenz.article.entity.Article;
 import com.example.Balenz.article.entity.FrameType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -39,4 +40,5 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
                                                                           @Param("frameType") String frameType);
     List<Article> findTop8ByKeyword_ServiceDateOrderByValueUserViewCountDesc(LocalDate serviceDate);
     List<Article> findTop8ByKeyword_ServiceDateOrderByNormUserViewCountDesc(LocalDate serviceDate);
+    List<Article> findByKeyword_ServiceDateAndFrameTypeIn(LocalDate serviceDate, List<FrameType> frameTypes, Pageable pageable);
 }

--- a/src/main/java/com/example/Balenz/article/service/ArticleService.java
+++ b/src/main/java/com/example/Balenz/article/service/ArticleService.java
@@ -1,23 +1,31 @@
 package com.example.Balenz.article.service;
 
+import com.example.Balenz.article.dto.ArticlesByIdeologyDto;
 import com.example.Balenz.article.dto.ArticlesByIdeologyInterestDto;
 import com.example.Balenz.article.dto.SimpleArticleDto;
 import com.example.Balenz.article.entity.Article;
+import com.example.Balenz.article.entity.FrameType;
 import com.example.Balenz.article.repository.ArticleRepository;
-import com.example.Balenz.keyword.service.HotKeywordService;
 import com.example.Balenz.keyword.service.KeywordService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ArticleService {
 
+    private static final int ARTICLE_LIMIT = 10;
+    private static final int CANDIDATE_LIMIT = 30;
+
     private final ArticleRepository articleRepository;
     private final KeywordService keywordService;
+
     public ArticlesByIdeologyInterestDto getArticlesByIdeologyInterest() {
         LocalDate serviceDate = keywordService.getCurrentServiceDate();
         List<Article> top8ValueUserViewCountArticles = articleRepository.findTop8ByKeyword_ServiceDateOrderByValueUserViewCountDesc(serviceDate);
@@ -33,6 +41,35 @@ public class ArticleService {
         return ArticlesByIdeologyInterestDto.builder()
                 .valueInterestArticles(valueInterestArticles)
                 .normInterestArticles(normInterestArticles).build();
+    }
+
+    public ArticlesByIdeologyDto getArticlesByIdeology() {
+        LocalDate serviceDate = keywordService.getCurrentServiceDate();
+
+        List<Article> valueArticleCandidates = articleRepository.findByKeyword_ServiceDateAndFrameTypeIn(serviceDate,
+                List.of(FrameType.STRONG_VALUE, FrameType.VALUE),
+                PageRequest.of(0, CANDIDATE_LIMIT));
+        List<Article> normArticleCandidates = articleRepository.findByKeyword_ServiceDateAndFrameTypeIn(serviceDate,
+                List.of(FrameType.STRONG_NORM, FrameType.NORM),
+                PageRequest.of(0, CANDIDATE_LIMIT));
+        List<SimpleArticleDto> neutralArticles = articleRepository.findByKeyword_ServiceDateAndFrameTypeIn(serviceDate,
+                        List.of(FrameType.NEUTRAL),
+                        PageRequest.of(0, ARTICLE_LIMIT))
+                .stream()
+                .map(this::toSimpleArticleDtoWithoutImage).toList();
+
+        return ArticlesByIdeologyDto.builder()
+                .value(getRandomArticlesFromCandidates(valueArticleCandidates))
+                .neutral(neutralArticles)
+                .norm(getRandomArticlesFromCandidates(normArticleCandidates)).build();
+    }
+
+    private List<SimpleArticleDto> getRandomArticlesFromCandidates(List<Article> articleCandidates) {
+        List<Article> shuffledArticles = new ArrayList<>(articleCandidates);
+        Collections.shuffle(shuffledArticles);
+        return shuffledArticles.stream()
+                .limit(ARTICLE_LIMIT)
+                .map(this::toSimpleArticleDtoWithoutImage).toList();
     }
 
     private SimpleArticleDto toSimpleArticleDtoWithoutImage(Article article) {


### PR DESCRIPTION
## ✅ 관련 이슈
closed #24 

## ✨ 작업 내용
- VALUE, NEUTRAL, NORM 프레임별로 오늘 날짜의 기사 랜덤으로 10개씩 반환하도록 구현
- STRONG_VALUE (STRONG_NORM)와 VALUE (NORM) 합쳐서 기사 30개 조회 후 그 중 랜덤으로 10개 뽑음

## 📸 스크린샷


## 🗨️ 참고 사항
