### PR TITLE
[Feat] 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/example/Balenz/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/Balenz/global/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
     // User 관련
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "회원가입 시 이메일은 필수입니다."),
+    LOCAL_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 일반 계정으로 가입된 이메일입니다. 일반 로그인을 진행해주세요."),
+    SOCIAL_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 소셜 계정으로 가입된 이메일입니다. 소셜 로그인을 진행해주세요."),
 
     // 소셜 로그인 관련
     INVALID_SOCIAL_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인입니다."),

--- a/src/main/java/com/example/Balenz/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/Balenz/global/security/CustomOAuth2UserService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,9 +47,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String providerId = userInfo.getProviderId();
 
         // 4. 해당 소셜 계정으로 이미 가입되어있는 경우 기존 user 가져오기, 없을 경우 생성
-        User user = socialAccountRepository.findByProviderAndProviderUserId(provider, providerId)
-                .map(SocialAccount::getUser)
-                .orElseGet(() -> createUserWithSocialAccount(provider, providerId, userInfo));
+        User user;
+        try {
+            user = socialAccountRepository.findByProviderAndProviderUserId(provider, providerId)
+                    .map(SocialAccount::getUser)
+                    .orElseGet(() -> createUserWithSocialAccount(provider, providerId, userInfo));
+        } catch (BaseException e) {
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error(e.getErrorCode().name()),
+                    e);
+        }
 
         return CustomPrincipal
                 .fromOAuth(user.getId(), user.getEmail(), user.getRole(), oAuth2User.getAttributes());
@@ -58,6 +66,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
         return switch (registrationId) {
             case "naver" -> new NaverOAuth2UserInfo(attributes);
+            case "kakao" -> new KakaoOAuth2UserInfo(attributes);
             default ->
                     throw new BaseException(ErrorCode.INVALID_SOCIAL_PROVIDER, "지원하지 않는 소셜 로그인입니다. - " + registrationId);
         };
@@ -81,20 +90,35 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new BaseException(ErrorCode.EMAIL_REQUIRED, provider + "에서 이메일을 제공받지 못했습니다.");
         }
 
-        // 이미 해당 이메일로 가입한 유저가 있는 경우 연결
-        User user = userRepository.findByEmail(email).orElseGet(() ->
-                userRepository.save(
-                        User.builder()
-                                .nickname(name)
-                                .imageUrl(imageUrl)
-                                .email(email)
-                                .role(Role.ROLE_USER).build()));
+        // 이미 해당 이메일로 가입한 유저가 있는 경우 에러
+        if (userRepository.existsByEmail(email)) {
+            socialAccountRepository.findByUser_Email(email)
+                    .ifPresentOrElse(
+                            // 소셜 계정으로 가입했던 경우
+                            socialAccount -> {
+                                Provider socialAccountProvider = socialAccount.getProvider();
+                                throw new BaseException(ErrorCode.SOCIAL_ACCOUNT_ALREADY_EXISTS,
+                                        socialAccountProvider.name());
+                            },
+                            // 일반 계정으로 가입했던 경우
+                            () -> {
+                                throw new BaseException(ErrorCode.LOCAL_ACCOUNT_ALREADY_EXISTS, "이미 일반 계정으로 가입된 이메일입니다. 일반 로그인을 진행해주세요.");
+                            }
+                    );
+        }
+
+        User user = userRepository.save(
+                User.builder()
+                        .nickname(name)
+                        .imageUrl(imageUrl)
+                        .email(email)
+                        .role(Role.ROLE_USER).build());
 
         SocialAccount socialAccount = SocialAccount.builder()
                 .provider(provider)
                 .providerUserId(providerUserId).build();
 
-        user.addSocialAccount(socialAccount);
+        user.linkSocialAccount(socialAccount);
         socialAccountRepository.save(socialAccount);
 
         return user;

--- a/src/main/java/com/example/Balenz/global/security/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/example/Balenz/global/security/KakaoOAuth2UserInfo.java
@@ -1,0 +1,58 @@
+package com.example.Balenz.global.security;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+
+    /**
+     * 카카오 응답 구조
+     * {
+     *   "id": ...,
+     *   "kakao_account": {
+     *     "email": "...",
+     *     "profile": {
+     *       "nickname": "...",
+     *       "profile_image_url": "https://..."
+     *     }
+     *   }
+     * }
+     */
+    private final Map<String, Object> attributes; // 응답 원본
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = kakaoAccount == null ? null : (Map<String, Object>) kakaoAccount.get("profile");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getProvider() { return "kakao"; }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getName() {
+        return profile.get("nickname").toString();
+    }
+
+    @Override
+    public String getImageUrl() {
+        return profile.get("profile_image_url").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        Object email = kakaoAccount.get("email");
+        return email != null ? email.toString() : null;
+    }
+}

--- a/src/main/java/com/example/Balenz/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/Balenz/global/security/SecurityConfig.java
@@ -21,8 +21,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Slf4j
@@ -46,7 +44,7 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                //.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/article/*/scrap", "/api/keyword/*/scrap").authenticated()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
@@ -63,6 +61,18 @@ public class SecurityConfig {
                             Throwable cause = e.getCause();
                             if (cause instanceof BaseException baseException) {
                                 error = baseException.getErrorCode().name();
+
+                                String target = REDIRECT_URI.contains("?") ? REDIRECT_URI + "&" : REDIRECT_URI + "?";
+
+                                String provider = "";
+                                String redirectUrl = target + "error=" + error;
+                                if (error.equals(ErrorCode.SOCIAL_ACCOUNT_ALREADY_EXISTS.name())) {
+                                    provider = baseException.getMessage();  // naver, kakao
+                                    redirectUrl += "&provider=" + provider;
+                                }
+
+                                response.sendRedirect(redirectUrl);
+                                return;
                             }
 
                             String target = REDIRECT_URI.contains("?") ? REDIRECT_URI + "&" : REDIRECT_URI + "?";

--- a/src/main/java/com/example/Balenz/user/entity/Provider.java
+++ b/src/main/java/com/example/Balenz/user/entity/Provider.java
@@ -1,5 +1,6 @@
 package com.example.Balenz.user.entity;
 
 public enum Provider {
-    NAVER
+    NAVER,
+    KAKAO
 }

--- a/src/main/java/com/example/Balenz/user/entity/SocialAccount.java
+++ b/src/main/java/com/example/Balenz/user/entity/SocialAccount.java
@@ -9,13 +9,19 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"provider", "provider_user_id"}),
+                @UniqueConstraint(columnNames = {"user_id"})
+        }
+)
 public class SocialAccount {
 
     @Id
     @GeneratedValue(strategy =  GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/example/Balenz/user/entity/User.java
+++ b/src/main/java/com/example/Balenz/user/entity/User.java
@@ -43,8 +43,8 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @OneToMany(mappedBy = "user", cascade = {CascadeType.MERGE, CascadeType.PERSIST})
-    private List<SocialAccount> socialAccounts = new ArrayList<>();
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private SocialAccount socialAccount;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RefreshToken> refreshTokens = new ArrayList<>();
@@ -58,8 +58,8 @@ public class User extends BaseTimeEntity {
         this.imageUrl = imageUrl;
     }
 
-    public void addSocialAccount(SocialAccount socialAccount) {
-        this.socialAccounts.add(socialAccount);
+    public void linkSocialAccount(SocialAccount socialAccount) {
+        this.socialAccount = socialAccount;
         socialAccount.setUser(this);
     }
 

--- a/src/main/java/com/example/Balenz/user/repository/SocialAccountRepository.java
+++ b/src/main/java/com/example/Balenz/user/repository/SocialAccountRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
     Optional<SocialAccount> findByProviderAndProviderUserId(Provider provider, String providerId);
+    Optional<SocialAccount> findByUser_Email(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,9 +25,25 @@ spring:
               - profile_image
             client-name: Naver
             authorization-grant-type: authorization_code
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - profile_nickname
+              - account_email
+              - profile_image
+            client-name: Kakao
+            authorization-grant-type: authorization_code
         provider:
           naver:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id


### PR DESCRIPTION
## ✅ 관련 이슈
closed #26 

## ✨ 작업 내용
- 카카오 로그인 구현
- 하나의 User 객체에 여러 SocialAccount가 연결되지 않도록 하기로 변경함에 따라 User-SocialAccount 관계를 OneToMany -> OneToOne으로 변경
- **소셜 로그인** 시도 시 이미 해당 이메일로 **일반 회원가입**을 한 사용자가 있는 경우 -> URL에 `error=LOCAL_ACCOUNT_ALREADY_EXISTS` 반환
- **일반 로그인 / 다른 provider로 소셜 로그인** 시도 시 해당 이메일로 **소셜 로그인**을 한 사용자가 있는 경우 -> URL에 `error=SOCIAL_ACCOUNT_ALREADY_EXISTS &provider=KAKAO 또는 NAVER` 반환

## 📸 스크린샷


## 🗨️ 참고 사항
