### PR TITLE
[Feat] 이념 페이지 / 검색 관련 수정

### DIFF
--- a/src/main/java/com/example/Balenz/article/entity/FrameType.java
+++ b/src/main/java/com/example/Balenz/article/entity/FrameType.java
@@ -5,5 +5,6 @@ public enum FrameType {
     VALUE,
     NEUTRAL,
     NORM,
-    STRONG_NORM
+    STRONG_NORM,
+    UNKNOWN
 }

--- a/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
@@ -14,7 +14,8 @@ import java.util.Optional;
 
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-    long countByKeywordIdAndFrameType(Long keywordId, FrameType frameType);
+    long countByKeywordIdAndFrameTypeIn(Long keywordId, List<FrameType> frameTypes);
+
     // 키워드 내 각 프레임타입별로 각각 가장 조회수가 높은 기사 조회
     @Query(value = """
         SELECT *
@@ -27,6 +28,20 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Optional<Article> findTopByKeyword_IdAndFrameTypeOrderByViewCountDesc(@Param("keywordId") Long keywordId,
                                                      @Param("frameType") String frameType);
 
+    // STRONG + 일반 이념 프레임타입 합쳐서 각각 가장 조회수가 높은 기사 조회
+    @Query(value = """
+    SELECT *
+    FROM Article
+    WHERE keyword_id = :keywordId
+      AND frame_type IN (:frameTypes)
+    ORDER BY (value_user_view_count + neutral_user_view_count + norm_user_view_count) DESC, id ASC
+    LIMIT 1
+""", nativeQuery = true)
+    Optional<Article> findTopByKeywordIdAndFrameTypeInOrderByViewCountDesc(
+            @Param("keywordId") Long keywordId,
+            @Param("frameTypes") List<String> frameTypes
+    );
+
     List<Article> findTop4ByKeyword_IdAndFrameTypeOrderByPublishedAtDesc(Long keywordId, FrameType frameType);
     @Query(value = """
         SELECT *
@@ -38,6 +53,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     """, nativeQuery = true)
     List<Article> findTop2ByKeyword_IdAndFrameTypeOrderByViewCountDesc(@Param("keywordId") Long keywordId,
                                                                           @Param("frameType") String frameType);
+
     List<Article> findTop8ByKeyword_ServiceDateOrderByValueUserViewCountDesc(LocalDate serviceDate);
     List<Article> findTop8ByKeyword_ServiceDateOrderByNormUserViewCountDesc(LocalDate serviceDate);
     List<Article> findByKeyword_ServiceDateAndFrameTypeIn(LocalDate serviceDate, List<FrameType> frameTypes, Pageable pageable);

--- a/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/Balenz/article/repository/ArticleRepository.java
@@ -57,5 +57,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findTop8ByKeyword_ServiceDateOrderByValueUserViewCountDesc(LocalDate serviceDate);
     List<Article> findTop8ByKeyword_ServiceDateOrderByNormUserViewCountDesc(LocalDate serviceDate);
     List<Article> findByKeyword_ServiceDateAndFrameTypeIn(LocalDate serviceDate, List<FrameType> frameTypes, Pageable pageable);
-    List<Article> findByTitleContaining(String query);
+    @Query("""
+    SELECT a
+    FROM Article a
+    WHERE REPLACE(a.title, ' ', '') LIKE CONCAT('%', REPLACE(:query, ' ', ''), '%')
+""")
+    List<Article> searchByTitle(@Param("query") String query);
 }

--- a/src/main/java/com/example/Balenz/keyword/dto/ScopeSectionResponseDto.java
+++ b/src/main/java/com/example/Balenz/keyword/dto/ScopeSectionResponseDto.java
@@ -10,13 +10,15 @@ import java.util.List;
 @Builder
 public class ScopeSectionResponseDto {
 
-    private MainKeywordDto mainKeyword;
+    private List<MainKeywordDto> mainKeywords;
 
     private List<KeywordDto> keywords;
 
     @Data
     @Builder
     public static class MainKeywordDto {
+
+        private String category;
 
         private Long id;
 

--- a/src/main/java/com/example/Balenz/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/example/Balenz/keyword/repository/KeywordRepository.java
@@ -11,9 +11,9 @@ import java.util.Optional;
 
 @Repository
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
-    List<Keyword> findTop7ByCategoryAndServiceDateOrderByViewCountDescIdDesc(Category category, LocalDate serviceDate);
-    List<Keyword> findTop7ByServiceDateOrderByViewCountDescIdDesc(LocalDate serviceDate);
+    List<Keyword> findTop6ByCategoryAndServiceDateOrderByViewCountDescIdDesc(Category category, LocalDate serviceDate);
     Optional<Keyword> findByNameAndCategoryAndServiceDate(String name, Category category, LocalDate serviceDate);
     List<Keyword> findTop6ByServiceDateOrderByViewCountDescIdDesc(LocalDate serviceDate);
     List<Keyword> findByNameContaining(String query);
+    Optional<Keyword> findTopByCategoryAndServiceDateOrderByViewCountDescIdDesc(Category category, LocalDate serviceDate);
 }

--- a/src/main/java/com/example/Balenz/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/example/Balenz/keyword/repository/KeywordRepository.java
@@ -3,6 +3,8 @@ package com.example.Balenz.keyword.repository;
 import com.example.Balenz.keyword.entity.Category;
 import com.example.Balenz.keyword.entity.Keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -14,6 +16,11 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     List<Keyword> findTop6ByCategoryAndServiceDateOrderByViewCountDescIdDesc(Category category, LocalDate serviceDate);
     Optional<Keyword> findByNameAndCategoryAndServiceDate(String name, Category category, LocalDate serviceDate);
     List<Keyword> findTop6ByServiceDateOrderByViewCountDescIdDesc(LocalDate serviceDate);
-    List<Keyword> findByNameContaining(String query);
+    @Query("""
+    SELECT k
+    FROM Keyword k
+    WHERE REPLACE(k.name, ' ', '') LIKE CONCAT('%', REPLACE(:query, ' ', ''), '%')
+""")
+    List<Keyword> searchByName(@Param("query") String query);
     Optional<Keyword> findTopByCategoryAndServiceDateOrderByViewCountDescIdDesc(Category category, LocalDate serviceDate);
 }

--- a/src/main/java/com/example/Balenz/keyword/service/KeywordService.java
+++ b/src/main/java/com/example/Balenz/keyword/service/KeywordService.java
@@ -14,9 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Stream;
 
 @Service
@@ -33,39 +31,47 @@ public class KeywordService {
 
         List<Keyword> keywords;
         if (category == null) { // 전체 조회
-            keywords = keywordRepository.findTop7ByServiceDateOrderByViewCountDescIdDesc(serviceDate);
+            keywords = keywordRepository.findTop6ByServiceDateOrderByViewCountDescIdDesc(serviceDate);
         } else {
-            keywords = keywordRepository.findTop7ByCategoryAndServiceDateOrderByViewCountDescIdDesc(category, serviceDate);
+            keywords = keywordRepository.findTop6ByCategoryAndServiceDateOrderByViewCountDescIdDesc(category, serviceDate);
         }
 
         // 2. DTO 생성
-        // 2-1. MainKeywordDto
-        if (keywords.isEmpty()) {
-            return ScopeSectionResponseDto.builder()
-                    .mainKeyword(null)
-                    .keywords(List.of()).build();
-        }
-        Keyword main = keywords.get(0);
+        // 2-1. MainKeywordDto 리스트
+        List<ScopeSectionResponseDto.MainKeywordDto> mainKeywordDtos = getMainKeywordDtos(serviceDate);
 
-        Optional<Article> valueArticle = articleRepository.findTopByKeyword_IdAndFrameTypeOrderByViewCountDesc(main.getId(), FrameType.VALUE.name());
-        Optional<Article> normArticle = articleRepository.findTopByKeyword_IdAndFrameTypeOrderByViewCountDesc(main.getId(), FrameType.NORM.name());
-        ScopeSectionResponseDto.MainKeywordDto mainKeywordDto = ScopeSectionResponseDto.MainKeywordDto.builder()
-                .id(main.getId())
-                .name(main.getName())
-                .articleCount(getArticleCount(main.getId()))
-                .valueArticleTitle(valueArticle.isPresent() ? valueArticle.get().getTitle() : null)
-                .valueImageUrl(valueArticle.isPresent() ? valueArticle.get().getImageUrl() : null)
-                .normArticleTitle(normArticle.isPresent() ? normArticle.get().getTitle() : null)
-                .normImageUrl(normArticle.isPresent() ? normArticle.get().getImageUrl() : null).build();
-
-        // 2-2. KeywordDto 리스트
-        List<Keyword> subKeywords = keywords.stream().skip(1).toList();
-        List<KeywordDto> keywordDtos = getKeywordDtos(subKeywords);
-
-
+        // 2-2. 카테고리별 KeywordDto 리스트
+        List<KeywordDto> keywordDtos = keywords.isEmpty() ? List.of() : getKeywordDtos(keywords);
+        
         return ScopeSectionResponseDto.builder()
-                .mainKeyword(mainKeywordDto)
+                .mainKeywords(mainKeywordDtos)
                 .keywords(keywordDtos).build();
+    }
+
+    /** mainKeywords 조회 */
+    private List<ScopeSectionResponseDto.MainKeywordDto> getMainKeywordDtos(LocalDate serviceDate) {
+        List<Category> categories = Arrays.asList(Category.values());
+        List<ScopeSectionResponseDto.MainKeywordDto> mainKeywords = new ArrayList<>();
+
+        for (Category category : categories) {
+            Keyword mainKeyword = keywordRepository.findTopByCategoryAndServiceDateOrderByViewCountDescIdDesc(category, serviceDate).orElse(null);
+            if (mainKeyword != null) {
+                Article valueArticle = articleRepository.findTopByKeywordIdAndFrameTypeInOrderByViewCountDesc(mainKeyword.getId(), List.of(FrameType.VALUE.name(), FrameType.STRONG_VALUE.name())).orElse(null);
+                Article normArticle = articleRepository.findTopByKeywordIdAndFrameTypeInOrderByViewCountDesc(mainKeyword.getId(), List.of(FrameType.NORM.name(), FrameType.STRONG_NORM.name())).orElse(null);
+
+                mainKeywords.add(ScopeSectionResponseDto.MainKeywordDto.builder()
+                        .category(category.name())
+                        .id(mainKeyword.getId())
+                        .name(mainKeyword.getName())
+                        .articleCount(getArticleCount(mainKeyword.getId()))
+                        .valueArticleTitle(valueArticle != null ? valueArticle.getTitle() : null)
+                        .valueImageUrl(valueArticle != null ? valueArticle.getImageUrl() : null)
+                        .normArticleTitle(normArticle != null ? normArticle.getTitle() : null)
+                        .normImageUrl(normArticle != null ? normArticle.getImageUrl() : null).build());
+            }
+        }
+
+        return mainKeywords;
     }
 
     /** Keyword 리스트 -> KeywordDto 리스트 */
@@ -85,9 +91,9 @@ public class KeywordService {
 
     /** 키워드에 해당하는 프레임별 기사 수 */
     public ScopeSectionResponseDto.ArticleCountDto getArticleCount(Long keywordId) {
-        long valueCount = articleRepository.countByKeywordIdAndFrameType(keywordId, FrameType.VALUE);
-        long neutralCount = articleRepository.countByKeywordIdAndFrameType(keywordId, FrameType.NEUTRAL);
-        long normCount = articleRepository.countByKeywordIdAndFrameType(keywordId, FrameType.NORM);
+        long valueCount = articleRepository.countByKeywordIdAndFrameTypeIn(keywordId, List.of(FrameType.VALUE, FrameType.STRONG_VALUE));
+        long neutralCount = articleRepository.countByKeywordIdAndFrameTypeIn(keywordId, List.of(FrameType.NEUTRAL));
+        long normCount = articleRepository.countByKeywordIdAndFrameTypeIn(keywordId, List.of(FrameType.NORM, FrameType.STRONG_NORM));
         long total = valueCount + neutralCount + normCount;
 
         return ScopeSectionResponseDto.ArticleCountDto.builder()

--- a/src/main/java/com/example/Balenz/search/service/SearchService.java
+++ b/src/main/java/com/example/Balenz/search/service/SearchService.java
@@ -24,8 +24,8 @@ public class SearchService {
     private final ArticleService articleService;
 
     public SearchResponseDto search(String query) {
-        List<Keyword> keywords = keywordRepository.findByNameContaining(query);
-        List<Article> articles = articleRepository.findByTitleContaining(query);
+        List<Keyword> keywords = keywordRepository.searchByName(query);
+        List<Article> articles = articleRepository.searchByTitle(query);
 
         return new SearchResponseDto(
                 keywordService.getKeywordDtos(keywords),


### PR DESCRIPTION
## ✅ 관련 이슈
closed #35 

## ✨ 작업 내용
### 1. 스코프 섹션에서 모든 카테고리의 메인 키워드 한 번에 조회하도록 수정
**[기존 방식]** category 쿼리 파라미터 값에 따라 해당 category의 메인 키워드 하나만 반환
**[수정 이유]** 메인 키워드 섹션과 카테고리별 인기 키워드 섹션이 독립적으로 동작함에 따라 category에 관계없이 메인 키워드 리스트 조회 필요
**[수정]** category 쿼리 파라미터 값에 관계없이 모든 category의 메인 키워드 모두 반환하도록 수정

### 2. FrameType에 UNKNOWN 추가
**[기존 방식]** FrameType에 UNKNOWN 존재 X
**[수정 이유]** 기사 프레임타입 추출 과정에서 프레임을 판단하기 어려운 경우도 존재함
**[수정]** FrameType에 UNKNOWN 추가

### 3. 검색 시 공백 무시하도록 수정
**[기존 방식]** 검색어와 기사제목/키워드가 공백까지 일치해야 검색이 가능했음 `(e.g. '숙명여자 대학교'로는 '숙명여자대학교' 검색 불가)`
**[수정 이유]** 사용자가 공백까지 정확하게 입력하지 않아도 원하는 결과를 검색할 수 있도록 사용자 경험 개선 필요
**[수정]** `REPLACE()` 함수를 통해 검색어와 검색 대상의 공백 제거하고 비교하도록 수정하여 공백 무시하고 검색 가능하도록 개선

## 📸 스크린샷


## 🗨️ 참고 사항
