### PR TITLE
[Feat] 기사 이념 분류 불가한 경우 처리 구현

### DIFF
--- a/src/main/java/com/example/Balenz/article/controller/AdminArticleController.java
+++ b/src/main/java/com/example/Balenz/article/controller/AdminArticleController.java
@@ -1,6 +1,7 @@
 package com.example.Balenz.article.controller;
 
 import com.example.Balenz.article.dto.ArticleSaveRequestDto;
+import com.example.Balenz.article.dto.FrameTypeUpdateRequestDto;
 import com.example.Balenz.article.service.AdminArticleService;
 import com.example.Balenz.global.response.BaseResponse;
 import jakarta.validation.Valid;
@@ -21,6 +22,13 @@ public class AdminArticleController {
     @PostMapping
     public ResponseEntity<?> saveArticle(@Valid @RequestBody ArticleSaveRequestDto articleSaveRequestDto) {
         adminArticleService.saveArticle(articleSaveRequestDto);
+        return ResponseEntity.ok()
+                .body(BaseResponse.success(null));
+    }
+
+    @PostMapping("/frame-type")
+    public ResponseEntity<?> updateArticleFrameType(@Valid @RequestBody FrameTypeUpdateRequestDto frameTypeUpdateRequestDto) {
+        adminArticleService.updateArticleFrameType(frameTypeUpdateRequestDto);
         return ResponseEntity.ok()
                 .body(BaseResponse.success(null));
     }

--- a/src/main/java/com/example/Balenz/article/dto/ArticleSaveRequestDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/ArticleSaveRequestDto.java
@@ -13,6 +13,9 @@ public class ArticleSaveRequestDto {
     private String title;
 
     @NotBlank
+    private String content;
+
+    @NotBlank
     private String articleUrl;
 
     private String imageUrl;

--- a/src/main/java/com/example/Balenz/article/dto/FrameTypeUpdateRequestDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/FrameTypeUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.Balenz.article.dto;
+
+import com.example.Balenz.article.entity.FrameType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class FrameTypeUpdateRequestDto {
+
+    @NotNull
+    private Long articleId;
+
+    @NotNull
+    private FrameType frameType;
+
+}

--- a/src/main/java/com/example/Balenz/article/entity/Article.java
+++ b/src/main/java/com/example/Balenz/article/entity/Article.java
@@ -29,14 +29,6 @@ public class Article extends BaseTimeEntity {
 
     private String summary;
 
-    // 가치 프레임 점수
-    @Column(nullable = false)
-    private Double valueScore;
-
-    // 규범 프레임 점수
-    @Column(nullable = false)
-    private Double normScore;
-
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private FrameType frameType;
@@ -78,14 +70,12 @@ public class Article extends BaseTimeEntity {
 
     @Builder
     public Article(String title, String articleUrl, String imageUrl, String summary,
-                   Double valueScore, Double normScore, FrameType frameType,
+                   FrameType frameType,
                    LocalDate publishedAt, NewsAgency newsAgency, Keyword keyword) {
         this.title = title;
         this.articleUrl = articleUrl;
         this.imageUrl = imageUrl;
         this.summary = summary;
-        this.valueScore = valueScore;
-        this.normScore = normScore;
         this.frameType = frameType;
         this.publishedAt = publishedAt;
         this.newsAgency = newsAgency;
@@ -106,6 +96,10 @@ public class Article extends BaseTimeEntity {
 
     public void increaseNormUserViewCount() {
         this.normUserViewCount++;
+    }
+
+    public void updateFrameType(FrameType frameType) {
+        this.frameType = frameType;
     }
 
 }

--- a/src/main/java/com/example/Balenz/article/service/AdminArticleService.java
+++ b/src/main/java/com/example/Balenz/article/service/AdminArticleService.java
@@ -1,16 +1,21 @@
 package com.example.Balenz.article.service;
 
 import com.example.Balenz.article.dto.ArticleSaveRequestDto;
+import com.example.Balenz.article.dto.FrameTypeUpdateRequestDto;
 import com.example.Balenz.article.entity.Article;
 import com.example.Balenz.article.entity.FrameType;
 import com.example.Balenz.article.entity.NewsAgency;
 import com.example.Balenz.article.repository.ArticleRepository;
 import com.example.Balenz.article.repository.NewsAgencyRepository;
+import com.example.Balenz.global.email.EmailService;
+import com.example.Balenz.global.exception.BaseException;
+import com.example.Balenz.global.exception.ErrorCode;
 import com.example.Balenz.keyword.entity.Category;
 import com.example.Balenz.keyword.entity.Keyword;
 import com.example.Balenz.keyword.repository.KeywordRepository;
 import com.example.Balenz.keyword.service.KeywordService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,43 +23,24 @@ import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminArticleService {
 
     private final NewsAgencyRepository newsAgencyRepository;
     private final KeywordRepository keywordRepository;
     private final ArticleRepository articleRepository;
     private final KeywordService keywordService;
+    private final EmailService emailService;
 
     @Transactional
     public void saveArticle(ArticleSaveRequestDto articleSaveRequestDto) {
-        // 1. 프레임별 점수 계산
-        // TODO : 점수 계산 연동
-        Double valueScore = 0.038;
-        Double normScore = 0.012;
-
-        // 2. 프레임 타입 지정
-        // TODO : 프레임 타입 지정 기준 논의 후 반영
-        FrameType frameType;
-        // intensity 작으면 약한 프레임 기사
-        Double intensity = valueScore + normScore;
-        // balanceRatio 작으면 중립 기사
-        Double balanceRatio = Math.abs(valueScore - normScore) / intensity;
-        if (intensity < 0.03 || balanceRatio < 0.2) {
-            frameType = FrameType.NEUTRAL;
-        } else {
-            frameType = valueScore > normScore ? FrameType.VALUE : FrameType.NORM;
-        }
-
-        // 3. 기사 요약
-        // TODO : 기사 요약 연동
-
-        // 4. 언론사 조회 - 없으면 생성
+        // 1. 언론사 조회 - 없으면 생성
         NewsAgency newsAgency = newsAgencyRepository.findByName(articleSaveRequestDto.getNewsAgencyName())
                 .orElseGet(() -> newsAgencyRepository.save(
                         NewsAgency.builder().name(articleSaveRequestDto.getNewsAgencyName()).build()
                 ));
 
-        // 5. 키워드 추출
+        // 2. 키워드 추출
         // TODO : 키워드 및 카테고리 추출 로직 연동
         String keywordName = "경찰청";
         Category category = Category.SOCIETY;
@@ -70,17 +56,61 @@ public class AdminArticleService {
                                 .serviceDate(preparedServiceDate).build()
                 ));
 
-        articleRepository.save(Article.builder()
+        // 3. 기사 요약
+        // TODO : 기사 요약 연동
+        String summary = "요약내용";
+
+        // 4. 프레임타입 UNKNOWN으로 article 저장
+        Article article = articleRepository.save(Article.builder()
                 .title(articleSaveRequestDto.getTitle())
                 .articleUrl(articleSaveRequestDto.getArticleUrl())
                 .imageUrl(articleSaveRequestDto.getImageUrl())
-                .summary("요약요약")
-                .valueScore(valueScore)
-                .normScore(normScore)
-                .frameType(frameType)
+                .summary(summary)
+                .frameType(FrameType.UNKNOWN)
                 .publishedAt(articleSaveRequestDto.getPublishedAt())
                 .newsAgency(newsAgency)
                 .keyword(keyword).build());
+
+        // 5. 이념 분류 가능 여부 판별
+        // TODO : 연동
+        String result = "N";
+
+        // 5-1. 이념 분류 불가할 경우 수동 추출 요청 이메일 전송
+        if ("N".equals(result)) {
+            try {
+                emailService.sendEmail(
+                        "[이념 분류 실패] 수동 이념 분류가 필요합니다. #" + article.getId(),
+                        """
+                        - 기사 ID: %d
+                        - 기사 제목: %s
+                        - 기사 내용: %s
+                        
+                        - 업로드 예정일: %s
+                        """.formatted(
+                                article.getId(),
+                                article.getTitle(),
+                                articleSaveRequestDto.getContent(),
+                                preparedServiceDate
+                        )
+                );
+            } catch (Exception e) {
+                log.error("수동 이념 분류 요청 이메일 전송 실패 - articleId={}", article.getId(), e);
+            }
+            return;
+        }
+
+        // 5-2. 이념 분류 가능한 경우 이념 추출
+        // TODO : 연동
+        FrameType frameType = FrameType.NEUTRAL;
+        article.updateFrameType(frameType);
+    }
+
+    @Transactional
+    public void updateArticleFrameType(FrameTypeUpdateRequestDto frameTypeUpdateRequestDto) {
+        Article article = articleRepository.findById(frameTypeUpdateRequestDto.getArticleId()).orElseThrow(
+                () -> new BaseException(ErrorCode.ARTICLE_NOT_FOUND, "해당 id의 기사가 존재하지 않습니다."));
+
+        article.updateFrameType(frameTypeUpdateRequestDto.getFrameType());
     }
 
 }

--- a/src/main/java/com/example/Balenz/global/email/EmailService.java
+++ b/src/main/java/com/example/Balenz/global/email/EmailService.java
@@ -1,0 +1,25 @@
+package com.example.Balenz.global.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    /** 이메일 전송 */
+    public void sendEmail(String subject, String content) {
+        SimpleMailMessage message = new SimpleMailMessage();
+
+        message.setTo("team.balenz@gmail.com");
+        message.setSubject(subject);
+        message.setText(content);
+
+        mailSender.send(message);
+    }
+
+}

--- a/src/main/java/com/example/Balenz/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/Balenz/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.example.Balenz.global.exception;
 import com.example.Balenz.global.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -60,6 +61,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
                 .body(BaseResponse.error(ErrorCode.INVALID_INPUT_VALUE, "잘못된 쿼리 파라미터입니다."));
+    }
+
+    // 요청 본문 파싱에 실패한 경우 (Enum 값이 잘못된 경우 등)
+    @ExceptionHandler(HttpMessageNotReadableException .class)
+    public ResponseEntity<BaseResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("HttpMessageNotReadableException - " + e.getMessage());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(BaseResponse.error(ErrorCode.INVALID_INPUT_VALUE, "잘못된 요청 본문입니다."));
     }
 
     // 쿼리 파라미터 누락된 경우

--- a/src/main/java/com/example/Balenz/report/service/ReportService.java
+++ b/src/main/java/com/example/Balenz/report/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.example.Balenz.report.service;
 
 import com.example.Balenz.article.repository.ArticleRepository;
+import com.example.Balenz.global.email.EmailService;
 import com.example.Balenz.global.exception.BaseException;
 import com.example.Balenz.global.exception.ErrorCode;
 import com.example.Balenz.keyword.repository.KeywordRepository;
@@ -13,8 +14,6 @@ import com.example.Balenz.user.entity.User;
 import com.example.Balenz.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +26,7 @@ public class ReportService {
     private final KeywordRepository keywordRepository;
     private final ReportRepository reportRepository;
     private final AuthService authService;
-    private final JavaMailSender mailSender;
+    private final EmailService emailService;
 
     @Transactional
     public void submitReport(ReportSubmitRequestDto requestDto, Long userId) {
@@ -65,8 +64,8 @@ public class ReportService {
 
         // DB에 저장 후 이메일 전송
         try {
-            sendReportEmail(
-                    "[Balenz] 문제 제보가 접수되었습니다. #" + report.getId(),
+            emailService.sendEmail(
+                    "[문제 제보] 문제 제보가 접수되었습니다. #" + report.getId(),
                     """
                     - 제보 ID: %d
                     
@@ -88,17 +87,6 @@ public class ReportService {
         } catch (Exception e) {
             log.error("문제 제보 이메일 전송 실패 - reportId={}", report.getId(), e);
         }
-    }
-
-    /** 이메일 전송 */
-    private void sendReportEmail(String subject, String content) {
-        SimpleMailMessage message = new SimpleMailMessage();
-
-        message.setTo("team.balenz@gmail.com");
-        message.setSubject(subject);
-        message.setText(content);
-
-        mailSender.send(message);
     }
 
 }


### PR DESCRIPTION
## ✅ 관련 이슈
closed #37 

## ✨ 작업 내용
### 1. 기사 저장 시 이념 분류 실패한 경우 처리 구현
**[기사 저장 기능 흐름]**

** Claude API, 기사 API 연동 전
1. DB에서 언론사 조회 / 없을 경우 생성
2. Claude API를 통해 기사 키워드 추출 (기사 API에서 키워드까지 제공해준다면 스킵)
3. Claude API를 통해 기사 요약
4. 프레임타입 UNKNOWN으로 기사 저장
5. Claude API를 통해 이념 분류 가능 여부 판별
    - 가능한 경우 이념 분류 후 해당 프레임타입으로 업데이트
    - 불가한 경우 수동 이념 분류 요청 이메일 전송
    → ‘기사 이념 수동 지정’ API를 통해 수동 이념 분류

### 2. 기사 이념 수동 지정 기능 구현
Claude API를 통해 이념 분류가 불가한 경우 혹은 기사 이념을 수정하고 싶은 경우 수동으로 기사 이념 (FrameType)을 수정할 수 있도록 구현

### 3. Article에서 valueScore, normScore 필드 제거
**[기존 방식]** 기존에는 직접 valueScore과 normScore를 계산해서 더 큰 값을 가지는 이념으로 분류하는 방식을 사용하려 했기 때문에 Article에 valueScore, normScore 필드를 두었음
**[수정 이유]** 직접 점수를 계산해서 분류하는 대신 Claude API를 사용해서 분류하는 것으로 변경함에 따라 valueScore, normScore 필드가 불필요해짐
**[수정]** valueScore, normScore 필드 제거

## 📸 스크린샷


## 🗨️ 참고 사항
