### PR TITLE
[Feat] 데일리포커스 키워드 수동 지정 기능 구현

### DIFF
--- a/src/main/java/com/example/Balenz/dailyfocus/controller/AdminDailyFocusController.java
+++ b/src/main/java/com/example/Balenz/dailyfocus/controller/AdminDailyFocusController.java
@@ -1,0 +1,30 @@
+package com.example.Balenz.dailyfocus.controller;
+
+import com.example.Balenz.dailyfocus.dto.DailyFocusKeywordDto;
+import com.example.Balenz.dailyfocus.dto.DailyFocusUpdateRequestDto;
+import com.example.Balenz.dailyfocus.service.AdminDailyFocusService;
+import com.example.Balenz.global.response.BaseResponse;
+import com.example.Balenz.global.security.CustomPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/daily-focus")
+public class AdminDailyFocusController {
+
+    private final AdminDailyFocusService adminDailyFocusService;
+
+    @PutMapping
+    public ResponseEntity<?> updateDailyFocusKeyword(@Valid @RequestBody DailyFocusUpdateRequestDto updateRequestDto,
+                                                     @AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        List<DailyFocusKeywordDto> dailyFocus = adminDailyFocusService.updateDailyFocusKeyword(updateRequestDto, customPrincipal.getId());
+        return ResponseEntity.ok(BaseResponse.success(dailyFocus));
+    }
+
+}

--- a/src/main/java/com/example/Balenz/dailyfocus/dto/DailyFocusCacheDto.java
+++ b/src/main/java/com/example/Balenz/dailyfocus/dto/DailyFocusCacheDto.java
@@ -1,6 +1,7 @@
 package com.example.Balenz.dailyfocus.dto;
 
 import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
+import com.example.Balenz.keyword.entity.Category;
 
 import java.util.List;
 
@@ -9,6 +10,7 @@ public record DailyFocusCacheDto(
         String name,
         String imageUrl,
         ScopeSectionResponseDto.ArticleCountDto articleCount,
-        List<DailyFocusArticleDto> articles
+        List<DailyFocusArticleDto> articles,
+        Category category
 ) {
 }

--- a/src/main/java/com/example/Balenz/dailyfocus/dto/DailyFocusKeywordDto.java
+++ b/src/main/java/com/example/Balenz/dailyfocus/dto/DailyFocusKeywordDto.java
@@ -1,6 +1,7 @@
 package com.example.Balenz.dailyfocus.dto;
 
 import com.example.Balenz.keyword.dto.ScopeSectionResponseDto;
+import com.example.Balenz.keyword.entity.Category;
 
 import java.util.List;
 
@@ -8,6 +9,7 @@ public record DailyFocusKeywordDto(
         Long id,
         String name,
         String imageUrl,
+        Category category,
         ScopeSectionResponseDto.ArticleCountDto articleCount,
         List<DailyFocusArticleDto> articles,
         boolean scraped

--- a/src/main/java/com/example/Balenz/dailyfocus/dto/DailyFocusUpdateRequestDto.java
+++ b/src/main/java/com/example/Balenz/dailyfocus/dto/DailyFocusUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.Balenz.dailyfocus.dto;
+
+import com.example.Balenz.keyword.entity.Category;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import jakarta.validation.constraints.NotNull;
+
+@Data
+public class DailyFocusUpdateRequestDto {
+
+    @NotNull
+    private Category category;
+
+    @NotBlank
+    private String name;
+
+}

--- a/src/main/java/com/example/Balenz/dailyfocus/service/AdminDailyFocusService.java
+++ b/src/main/java/com/example/Balenz/dailyfocus/service/AdminDailyFocusService.java
@@ -1,0 +1,40 @@
+package com.example.Balenz.dailyfocus.service;
+
+import com.example.Balenz.dailyfocus.dto.DailyFocusKeywordDto;
+import com.example.Balenz.dailyfocus.dto.DailyFocusUpdateRequestDto;
+import com.example.Balenz.global.exception.BaseException;
+import com.example.Balenz.global.exception.ErrorCode;
+import com.example.Balenz.keyword.entity.Category;
+import com.example.Balenz.keyword.entity.Keyword;
+import com.example.Balenz.keyword.repository.KeywordRepository;
+import com.example.Balenz.keyword.service.KeywordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDailyFocusService {
+
+    private final DailyFocusService dailyFocusService;
+    private final KeywordRepository keywordRepository;
+    private final KeywordService keywordService;
+    private final DailyFocusCacheService dailyFocusCacheService;
+
+    public List<DailyFocusKeywordDto> updateDailyFocusKeyword(DailyFocusUpdateRequestDto updateRequestDto,
+                                                              Long userId) {
+        String name = updateRequestDto.getName();
+        Category category = updateRequestDto.getCategory();
+        LocalDate serviceDate = keywordService.getCurrentServiceDate();
+        Keyword keyword = keywordRepository.findByNameAndCategoryAndServiceDate(name, category, serviceDate)
+                .orElseThrow(() -> new BaseException(ErrorCode.KEYWORD_NOT_FOUND, "해당 카테고리에 해당 이름의 키워드가 존재하지 않습니다."));
+
+        dailyFocusCacheService.refreshDailyFocusCache(keyword, category, serviceDate);
+
+        // 전체 데일리 포커스 키워드 반환
+        return dailyFocusService.getDailyFocus(userId);
+    }
+
+}

--- a/src/main/java/com/example/Balenz/dailyfocus/service/DailyFocusCacheService.java
+++ b/src/main/java/com/example/Balenz/dailyfocus/service/DailyFocusCacheService.java
@@ -9,6 +9,7 @@ import com.example.Balenz.keyword.entity.Category;
 import com.example.Balenz.keyword.entity.Keyword;
 import com.example.Balenz.keyword.repository.KeywordRepository;
 import com.example.Balenz.keyword.service.KeywordService;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,17 +35,39 @@ public class DailyFocusCacheService {
             sync = true
     )
     public DailyFocusCacheDto getDailyFocusCache(Category category, LocalDate serviceDate) {
-        // 1. 카테고리별 가장 조회수가 높은 키워드 조회
+        // 카테고리별 가장 조회수가 높은 키워드 조회
         Keyword keyword = keywordRepository.findTopByCategoryAndServiceDateOrderByViewCountDescIdDesc(category, serviceDate).orElse(null);
 
         if (keyword == null) return null;
 
+        return createDailyFocusCacheDto(keyword);
+    }
+
+    private DailyFocusArticleDto toDailyFocusArticleDto(Article article) {
+        return new DailyFocusArticleDto(
+                article.getId(),
+                article.getTitle(),
+                article.getNewsAgency().getName(),
+                article.getFrameType(),
+                article.getSummary()
+        );
+    }
+
+    @CachePut(
+            cacheNames = "daily-focus",
+            key = "#category.name() + ':' + #serviceDate"
+    )
+    public DailyFocusCacheDto refreshDailyFocusCache(Keyword keyword, Category category, LocalDate serviceDate) {
+        return createDailyFocusCacheDto(keyword);
+    }
+
+    private DailyFocusCacheDto createDailyFocusCacheDto(Keyword keyword) {
         Long keywordId = keyword.getId();
 
-        // 2. 조회수 순으로 키워드 내 기사 전체 조회
+        // 1. 조회수 순으로 키워드 내 기사 전체 조회
         List<Article> articles = articleRepository.findByKeywordIdOrderByTotalViewCountDesc(keywordId);
 
-        // 3. 프레임타입별 조회수가 가장 높은 기사 조회
+        // 2. 프레임타입별 조회수가 가장 높은 기사 조회
         Map<FrameType, Article> articleByFrameType = articles.stream()
                 .collect(Collectors.toMap(
                         Article::getFrameType,
@@ -52,7 +75,7 @@ public class DailyFocusCacheService {
                         (first, second) -> first
                 ));
 
-        // 4. 좌우별로 기사 1개씩 조회 - 양극단 우선
+        // 3. 좌우별로 기사 1개씩 조회 - 양극단 우선
         Article valueArticle = articleByFrameType.containsKey(FrameType.STRONG_VALUE)
                 ? articleByFrameType.get(FrameType.STRONG_VALUE)
                 : articleByFrameType.get(FrameType.VALUE);
@@ -70,7 +93,7 @@ public class DailyFocusCacheService {
             selectedArticles.add(normArticle);
         }
 
-        // 5. 좌우 중 없는 쪽이 있을 경우 중립 추가
+        // 4. 좌우 중 없는 쪽이 있을 경우 중립 추가
         Article neutralArticle = articleByFrameType.get(FrameType.NEUTRAL);
         if (selectedArticles.size() < 2 && neutralArticle != null) {
             selectedArticles.add(neutralArticle);
@@ -81,17 +104,8 @@ public class DailyFocusCacheService {
                 keyword.getName(),
                 keyword.getThumbnailUrl(),
                 keywordService.getArticleCount(keywordId),
-                selectedArticles.stream().map(this::toDailyFocusArticleDto).toList()
-        );
-    }
-
-    private DailyFocusArticleDto toDailyFocusArticleDto(Article article) {
-        return new DailyFocusArticleDto(
-                article.getId(),
-                article.getTitle(),
-                article.getNewsAgency().getName(),
-                article.getFrameType(),
-                article.getSummary()
+                selectedArticles.stream().map(this::toDailyFocusArticleDto).toList(),
+                keyword.getCategory()
         );
     }
 

--- a/src/main/java/com/example/Balenz/dailyfocus/service/DailyFocusService.java
+++ b/src/main/java/com/example/Balenz/dailyfocus/service/DailyFocusService.java
@@ -43,6 +43,7 @@ public class DailyFocusService {
                 dailyFocusCacheDto.id(),
                 dailyFocusCacheDto.name(),
                 dailyFocusCacheDto.imageUrl(),
+                dailyFocusCacheDto.category(),
                 dailyFocusCacheDto.articleCount(),
                 dailyFocusCacheDto.articles(),
                 isScraped


### PR DESCRIPTION
## ✅ 관련 이슈
closed #44 

## ✨ 작업 내용
#### 데일리포커스 키워드 수동 지정 기능 구현
category와 name을 기반으로 해당 카테고리의 데일리포커스 키워드를 수동으로 지정할 수 있도록 구현했습니다. 
데일리포커스 조회 API에 category를 함께 반환하도록 변경하여 현재 카테고리별로 어떤 키워드가 설정되어 있는지 쉽게 확인할 수 있도록 개선했습니다.

## 📸 스크린샷


## 🗨️ 참고 사항
