### PR TITLE
[Feat] 프롬프트 테스트용 API 구현

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gradle
+.idea
+build
+.env
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:17-jdk AS builder
+WORKDIR /app
+
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon
+
+COPY src src
+
+RUN ./gradlew bootJar -x test --no-daemon
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/app.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -64,3 +64,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+bootJar {
+    archiveFileName = 'app.jar'
+}

--- a/src/main/java/com/example/Balenz/article/dto/FrameTypeClassifiableDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/FrameTypeClassifiableDto.java
@@ -1,6 +1,6 @@
 package com.example.Balenz.article.dto;
 
-public record IdeologyClassifiableDto(
+public record FrameTypeClassifiableDto(
         boolean isClassifiable
 ) {
 }

--- a/src/main/java/com/example/Balenz/article/dto/FrameTypeClassifyDto.java
+++ b/src/main/java/com/example/Balenz/article/dto/FrameTypeClassifyDto.java
@@ -1,6 +1,6 @@
 package com.example.Balenz.article.dto;
 
-public record IdeologyClassifyDto(
+public record FrameTypeClassifyDto(
         String ideology,
         Double confidence,
         String reason

--- a/src/main/java/com/example/Balenz/article/external/prompt/FrameTypeClassifiablePrompt.java
+++ b/src/main/java/com/example/Balenz/article/external/prompt/FrameTypeClassifiablePrompt.java
@@ -1,6 +1,6 @@
 package com.example.Balenz.article.external.prompt;
 
-public class IdeologyClassifiablePrompt {
+public class FrameTypeClassifiablePrompt {
 
     public static String create(String articleContent) {
         return """

--- a/src/main/java/com/example/Balenz/article/external/prompt/FrameTypeClassifyPrompt.java
+++ b/src/main/java/com/example/Balenz/article/external/prompt/FrameTypeClassifyPrompt.java
@@ -1,6 +1,6 @@
 package com.example.Balenz.article.external.prompt;
 
-public class IdeologyClassifyPrompt {
+public class FrameTypeClassifyPrompt {
 
     public static String create(String articleContent) {
         return """

--- a/src/main/java/com/example/Balenz/article/service/AdminArticleService.java
+++ b/src/main/java/com/example/Balenz/article/service/AdminArticleService.java
@@ -5,8 +5,8 @@ import com.example.Balenz.article.entity.Article;
 import com.example.Balenz.article.entity.FrameType;
 import com.example.Balenz.article.entity.NewsAgency;
 import com.example.Balenz.article.external.ClaudeApiClient;
-import com.example.Balenz.article.external.prompt.IdeologyClassifiablePrompt;
-import com.example.Balenz.article.external.prompt.IdeologyClassifyPrompt;
+import com.example.Balenz.article.external.prompt.FrameTypeClassifiablePrompt;
+import com.example.Balenz.article.external.prompt.FrameTypeClassifyPrompt;
 import com.example.Balenz.article.external.prompt.KeywordPrompt;
 import com.example.Balenz.article.external.prompt.SummaryPrompt;
 import com.example.Balenz.article.repository.ArticleRepository;
@@ -96,14 +96,14 @@ public class AdminArticleService {
                 .keyword(keyword).build());
 
         // 5. 이념 분류 가능 여부 판별
-        IdeologyClassifiableDto ideologyClassifiableDto = claudeApiClient.getResponse(
-                IdeologyClassifiablePrompt.create(content),
+        FrameTypeClassifiableDto frameTypeClassifiableDto = claudeApiClient.getResponse(
+                FrameTypeClassifiablePrompt.create(content),
                 300L,
-                IdeologyClassifiableDto.class
+                FrameTypeClassifiableDto.class
         );
 
 
-        boolean isClassifiable = ideologyClassifiableDto.isClassifiable();
+        boolean isClassifiable = frameTypeClassifiableDto.isClassifiable();
 
         // 5-1. 이념 분류 불가할 경우 수동 추출 요청 이메일 전송
         if (!isClassifiable) {
@@ -130,13 +130,13 @@ public class AdminArticleService {
         }
 
         // 5-2. 이념 분류 가능한 경우 이념 추출
-        IdeologyClassifyDto ideologyClassifyDto = claudeApiClient.getResponse(
-                IdeologyClassifyPrompt.create(content),
+        FrameTypeClassifyDto frameTypeClassifyDto = claudeApiClient.getResponse(
+                FrameTypeClassifyPrompt.create(content),
                 1024L,
-                IdeologyClassifyDto.class
+                FrameTypeClassifyDto.class
         );
 
-        FrameType frameType = toFrameType(ideologyClassifyDto.ideology());
+        FrameType frameType = toFrameType(frameTypeClassifyDto.ideology());
         article.updateFrameType(frameType);
     }
 
@@ -148,7 +148,7 @@ public class AdminArticleService {
         article.updateFrameType(frameTypeUpdateRequestDto.getFrameType());
     }
 
-    private FrameType toFrameType(String ideology) {
+    public FrameType toFrameType(String ideology) {
         if (ideology == null || ideology.isBlank()) {
             throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "ideology 값이 비어있습니다.");
         }

--- a/src/main/java/com/example/Balenz/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/Balenz/global/config/RestTemplateConfig.java
@@ -1,0 +1,30 @@
+package com.example.Balenz.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+
+        JdkClientHttpRequestFactory requestFactory =
+                new JdkClientHttpRequestFactory(httpClient);
+
+        requestFactory.setReadTimeout(Duration.ofSeconds(60));
+
+        return new RestTemplate(requestFactory);
+    }
+
+}
+

--- a/src/main/java/com/example/Balenz/internal/controller/TestController.java
+++ b/src/main/java/com/example/Balenz/internal/controller/TestController.java
@@ -1,0 +1,38 @@
+package com.example.Balenz.internal.controller;
+
+import com.example.Balenz.global.response.BaseResponse;
+import com.example.Balenz.internal.dto.TestResponseDto;
+import com.example.Balenz.internal.service.TestService;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(
+        name = "Prompt Test",
+        description = "프롬프트 테스트용 API"
+)
+public class TestController {
+
+    private final TestService testService;
+
+    @GetMapping("/test")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정상 실행"),
+            @ApiResponse(responseCode = "404", description = "전달받은 쿼리파라미터 (id)에 해당하는 테스트 기사가 존재하지 않는 경우 (ARTICLE_NOT_FOUND)"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<?> testPrompt(@RequestParam("id") Long id) {
+        TestResponseDto testResponseDto = testService.testPrompt(id);
+        return ResponseEntity.ok(BaseResponse.success(testResponseDto));
+    }
+
+}

--- a/src/main/java/com/example/Balenz/internal/controller/TestController.java
+++ b/src/main/java/com/example/Balenz/internal/controller/TestController.java
@@ -2,16 +2,14 @@ package com.example.Balenz.internal.controller;
 
 import com.example.Balenz.global.response.BaseResponse;
 import com.example.Balenz.internal.dto.TestResponseDto;
+import com.example.Balenz.internal.service.TestArticleService;
 import com.example.Balenz.internal.service.TestService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
 
     private final TestService testService;
+    private final TestArticleService testArticleService;
 
     @GetMapping("/test")
     @ApiResponses({
@@ -33,6 +32,12 @@ public class TestController {
     public ResponseEntity<?> testPrompt(@RequestParam("id") Long id) {
         TestResponseDto testResponseDto = testService.testPrompt(id);
         return ResponseEntity.ok(BaseResponse.success(testResponseDto));
+    }
+
+    @PostMapping("/admin/test-data")
+    public ResponseEntity<?> saveTestArticleData() {
+        int savedArticleCount = testArticleService.saveTestArticleData();
+        return ResponseEntity.ok(BaseResponse.success(savedArticleCount));
     }
 
 }

--- a/src/main/java/com/example/Balenz/internal/controller/TestController.java
+++ b/src/main/java/com/example/Balenz/internal/controller/TestController.java
@@ -1,15 +1,19 @@
 package com.example.Balenz.internal.controller;
 
 import com.example.Balenz.global.response.BaseResponse;
+import com.example.Balenz.internal.dto.TestArticleResponseDto;
 import com.example.Balenz.internal.dto.TestResponseDto;
 import com.example.Balenz.internal.service.TestArticleService;
 import com.example.Balenz.internal.service.TestService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +33,7 @@ public class TestController {
             @ApiResponse(responseCode = "404", description = "전달받은 쿼리파라미터 (id)에 해당하는 테스트 기사가 존재하지 않는 경우 (ARTICLE_NOT_FOUND)"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
+    @Operation(description = "프롬프트 테스트")
     public ResponseEntity<?> testPrompt(@RequestParam("id") Long id) {
         TestResponseDto testResponseDto = testService.testPrompt(id);
         return ResponseEntity.ok(BaseResponse.success(testResponseDto));
@@ -38,6 +43,14 @@ public class TestController {
     public ResponseEntity<?> saveTestArticleData() {
         int savedArticleCount = testArticleService.saveTestArticleData();
         return ResponseEntity.ok(BaseResponse.success(savedArticleCount));
+    }
+
+    @GetMapping("/test-data")
+    @Operation(description = "테스트 기사 데이터 불러오기")
+    public ResponseEntity<?> getTestArticleData(@RequestParam("page") int page,
+                                                @RequestParam("size") int size) {
+        List<TestArticleResponseDto> testArticleData = testArticleService.getTestArticleData(page, size);
+        return ResponseEntity.ok(BaseResponse.success(testArticleData));
     }
 
 }

--- a/src/main/java/com/example/Balenz/internal/dto/ExternalArticleRequestDto.java
+++ b/src/main/java/com/example/Balenz/internal/dto/ExternalArticleRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.Balenz.internal.dto;
+
+public record ExternalArticleRequestDto(
+        String paginationMethod,
+        String publishedAtStart,
+        String publishedAtEnd,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/com/example/Balenz/internal/dto/ExternalArticleResponseDto.java
+++ b/src/main/java/com/example/Balenz/internal/dto/ExternalArticleResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.Balenz.internal.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ExternalArticleResponseDto {
+
+    private List<ExternalArticleDto> items;
+
+    @Data
+    public static class ExternalArticleDto {
+
+        private String title;
+
+        private String body;
+
+        private List<String> categories;
+
+    }
+
+}

--- a/src/main/java/com/example/Balenz/internal/dto/TestArticleResponseDto.java
+++ b/src/main/java/com/example/Balenz/internal/dto/TestArticleResponseDto.java
@@ -1,0 +1,8 @@
+package com.example.Balenz.internal.dto;
+
+public record TestArticleResponseDto(
+        Long id,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/com/example/Balenz/internal/dto/TestResponseDto.java
+++ b/src/main/java/com/example/Balenz/internal/dto/TestResponseDto.java
@@ -8,6 +8,8 @@ import lombok.Data;
 @Builder
 public class TestResponseDto {
 
+    private String content;
+
     private String keyword;
 
     private String summary;

--- a/src/main/java/com/example/Balenz/internal/dto/TestResponseDto.java
+++ b/src/main/java/com/example/Balenz/internal/dto/TestResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.Balenz.internal.dto;
+
+import com.example.Balenz.article.entity.FrameType;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TestResponseDto {
+
+    private String keyword;
+
+    private String summary;
+
+    private boolean isClassifiable;
+
+    private FrameType frameType;
+
+}

--- a/src/main/java/com/example/Balenz/internal/entity/TestArticle.java
+++ b/src/main/java/com/example/Balenz/internal/entity/TestArticle.java
@@ -1,5 +1,6 @@
 package com.example.Balenz.internal.entity;
 
+import com.example.Balenz.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TestArticle {
+public class TestArticle extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy =  GenerationType.IDENTITY)
@@ -20,5 +21,10 @@ public class TestArticle {
     @Lob
     @Column(columnDefinition = "LONGTEXT", nullable = false)
     private String content;
+
+    public TestArticle(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 
 }

--- a/src/main/java/com/example/Balenz/internal/entity/TestArticle.java
+++ b/src/main/java/com/example/Balenz/internal/entity/TestArticle.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -22,9 +24,12 @@ public class TestArticle extends BaseTimeEntity {
     @Column(columnDefinition = "LONGTEXT", nullable = false)
     private String content;
 
-    public TestArticle(String title, String content) {
+    private List<String> categories;
+
+    public TestArticle(String title, String content, List<String> categories) {
         this.title = title;
         this.content = content;
+        this.categories = categories;
     }
 
 }

--- a/src/main/java/com/example/Balenz/internal/entity/TestArticle.java
+++ b/src/main/java/com/example/Balenz/internal/entity/TestArticle.java
@@ -1,0 +1,24 @@
+package com.example.Balenz.internal.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TestArticle {
+
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(columnDefinition = "LONGTEXT", nullable = false)
+    private String content;
+
+}

--- a/src/main/java/com/example/Balenz/internal/repository/TestArticleRepository.java
+++ b/src/main/java/com/example/Balenz/internal/repository/TestArticleRepository.java
@@ -1,0 +1,7 @@
+package com.example.Balenz.internal.repository;
+
+import com.example.Balenz.internal.entity.TestArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestArticleRepository extends JpaRepository<TestArticle, Long> {
+}

--- a/src/main/java/com/example/Balenz/internal/service/TestArticleService.java
+++ b/src/main/java/com/example/Balenz/internal/service/TestArticleService.java
@@ -74,24 +74,22 @@ public class TestArticleService {
 
     /** TestArticle 저장 */
     private int saveTestArticles(List<ExternalArticleResponseDto.ExternalArticleDto> articles) {
-        List<String> forbiddenCategories = List.of("인물", "종합", "기타");
+        List<String> forbiddenCategories = List.of("인물", "종합", "기타", "오피니언");
         int count = 0;
 
         for (ExternalArticleResponseDto.ExternalArticleDto article : articles) {
             List<String> categories = article.getCategories();
 
-            boolean containsForbiddenCategory =
-                    categories != null
-                    && forbiddenCategories.stream().noneMatch(categories::contains);
-
-            if (containsForbiddenCategory) { // forbidden이 아닌 경우만 저장
+            if (categories != null
+                    && forbiddenCategories.stream().anyMatch(categories::contains)) { // forbidden에 속하는 카테고리를 포함하는 경우 저장 X
                 continue;
             }
 
             testArticleRepository.save(
                     new TestArticle(
                             article.getTitle(),
-                            article.getBody()
+                            article.getBody(),
+                            categories
                     ));
 
             count++;

--- a/src/main/java/com/example/Balenz/internal/service/TestArticleService.java
+++ b/src/main/java/com/example/Balenz/internal/service/TestArticleService.java
@@ -1,0 +1,182 @@
+package com.example.Balenz.internal.service;
+
+import com.example.Balenz.global.exception.BaseException;
+import com.example.Balenz.global.exception.ErrorCode;
+import com.example.Balenz.internal.dto.ExternalArticleRequestDto;
+import com.example.Balenz.internal.dto.ExternalArticleResponseDto;
+import com.example.Balenz.internal.entity.TestArticle;
+import com.example.Balenz.internal.repository.TestArticleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TestArticleService {
+
+    private final TestArticleRepository testArticleRepository;
+    @Value("${NEWS_API_URL}")
+    private String NEWS_API_URL;
+
+    @Value("${NEWS_API_KEY}")
+    private String NEWS_API_KEY;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public int saveTestArticleData() {
+        int page = 1;
+        int savedArticleCount = 0;
+
+        while (true) {
+            ExternalArticleResponseDto response;
+
+            try {
+                response = requestArticles(page);
+            } catch (BaseException e) {
+                // 실패한 페이지부터 중단하고 지금까지 저장한 건수를 반환한다.
+                log.warn(
+                        "외부 API {}페이지 조회 실패. 지금까지 저장한 {}건만 반영합니다. 원인: {}",
+                        page,
+                        savedArticleCount,
+                        e.getMessage()
+                );
+                break;
+            }
+
+            if (response.getItems().isEmpty()) {
+                break;
+            }
+
+            savedArticleCount += saveTestArticles(response.getItems());
+            page++;
+        }
+
+        return savedArticleCount;
+    }
+
+    /** TestArticle 저장 */
+    private int saveTestArticles(List<ExternalArticleResponseDto.ExternalArticleDto> articles) {
+        List<String> forbiddenCategories = List.of("인물", "종합", "기타");
+        int count = 0;
+
+        for (ExternalArticleResponseDto.ExternalArticleDto article : articles) {
+            List<String> categories = article.getCategories();
+
+            boolean containsForbiddenCategory =
+                    categories != null
+                    && forbiddenCategories.stream().noneMatch(categories::contains);
+
+            if (containsForbiddenCategory) { // forbidden이 아닌 경우만 저장
+                continue;
+            }
+
+            testArticleRepository.save(
+                    new TestArticle(
+                            article.getTitle(),
+                            article.getBody()
+                    ));
+
+            count++;
+        }
+
+        return count;
+    }
+
+    /** 외부 API로부터 기사 조회 */
+    private ExternalArticleResponseDto requestArticles(int page) {
+        try {
+            ExternalArticleRequestDto request = new ExternalArticleRequestDto(
+                    "PAGE",
+                    "2026-07-01",
+                    "2026-07-15",
+                    page,
+                    100
+            );
+
+            byte[] requestBody = objectMapper
+                    .writeValueAsString(request)
+                    .getBytes(StandardCharsets.UTF_8);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("X-API-KEY", NEWS_API_KEY);
+            headers.setContentLength(requestBody.length);
+            headers.set(HttpHeaders.CONNECTION, "close");
+
+            // 이 외부 API는 JSON 본문 전송 후 연결을 비정상 종료함
+            // -> execute()로 응답 스트림을 직접 읽어 연결 종료 전까지 받은 본문 보존
+            byte[] responseBody = restTemplate.execute(
+                    NEWS_API_URL,
+                    HttpMethod.POST,
+                    clientRequest -> {
+                        clientRequest.getHeaders().putAll(headers);
+                        clientRequest.getBody().write(requestBody);
+                    },
+                    response -> {
+                        // 수신한 응답 누적
+                        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+                        try {
+                            response.getBody().transferTo(buffer);
+                        } catch (IOException readException) {
+                            byte[] partialBody = buffer.toByteArray();
+
+                            // 응답 자체가 비어있는 경우 복구 X
+                            if (partialBody.length == 0) {
+                                throw readException;
+                            }
+
+                            try {
+                                // 완전한 JSON일 때만 부분 응답 사용
+                                objectMapper.readTree(partialBody);
+                                log.warn(
+                                        "외부 API 연결이 비정상 종료되었으나 수신된 응답은 완전한 JSON으로 확인되어 정상 처리했습니다. status: {}, contentLength: {}, 원인: {}",
+                                        response.getStatusCode(),
+                                        partialBody.length,
+                                        readException.getMessage()
+                                );
+                                return partialBody;
+                            } catch (Exception jsonException) {
+                                readException.addSuppressed(jsonException);
+                                throw readException;
+                            }
+                        }
+
+                        return buffer.toByteArray();
+                    }
+            );
+
+            if (responseBody == null || responseBody.length == 0) {
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
+            }
+
+            return objectMapper.readValue(
+                    responseBody,
+                    ExternalArticleResponseDto.class
+            );
+        } catch (ResourceAccessException e) {
+            log.error("외부 API 연결 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("외부 API 에러 - " + e.getMessage());
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/example/Balenz/internal/service/TestArticleService.java
+++ b/src/main/java/com/example/Balenz/internal/service/TestArticleService.java
@@ -4,11 +4,15 @@ import com.example.Balenz.global.exception.BaseException;
 import com.example.Balenz.global.exception.ErrorCode;
 import com.example.Balenz.internal.dto.ExternalArticleRequestDto;
 import com.example.Balenz.internal.dto.ExternalArticleResponseDto;
+import com.example.Balenz.internal.dto.TestArticleResponseDto;
 import com.example.Balenz.internal.entity.TestArticle;
 import com.example.Balenz.internal.repository.TestArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -177,6 +181,23 @@ public class TestArticleService {
             log.error("외부 API 에러 - " + e.getMessage());
             throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
         }
+    }
+
+    public List<TestArticleResponseDto> getTestArticleData(int page, int size) {
+        Pageable pageable = PageRequest.of(
+                page - 1,
+                size,
+                Sort.by(Sort.Direction.ASC, "id")
+        );
+
+        return testArticleRepository.findAll(pageable)
+                .getContent()
+                .stream()
+                .map(testArticle -> new TestArticleResponseDto(
+                        testArticle.getId(),
+                        testArticle.getTitle(),
+                        testArticle.getContent()
+                )).toList();
     }
 
 }

--- a/src/main/java/com/example/Balenz/internal/service/TestService.java
+++ b/src/main/java/com/example/Balenz/internal/service/TestService.java
@@ -63,6 +63,7 @@ public class TestService {
 
         if (!isClassifiable) {
             return TestResponseDto.builder()
+                    .content(testArticle.getContent())
                     .keyword(keywordExtractDto.keyword())
                     .summary(summary)
                     .isClassifiable(false)
@@ -77,6 +78,7 @@ public class TestService {
         );
 
         return TestResponseDto.builder()
+                .content(testArticle.getContent())
                 .keyword(keywordExtractDto.keyword())
                 .summary(summary)
                 .isClassifiable(true)

--- a/src/main/java/com/example/Balenz/internal/service/TestService.java
+++ b/src/main/java/com/example/Balenz/internal/service/TestService.java
@@ -1,0 +1,86 @@
+package com.example.Balenz.internal.service;
+
+import com.example.Balenz.article.dto.FrameTypeClassifiableDto;
+import com.example.Balenz.article.dto.FrameTypeClassifyDto;
+import com.example.Balenz.article.dto.KeywordExtractDto;
+import com.example.Balenz.article.dto.SummaryDto;
+import com.example.Balenz.article.entity.FrameType;
+import com.example.Balenz.article.external.ClaudeApiClient;
+import com.example.Balenz.article.external.prompt.FrameTypeClassifiablePrompt;
+import com.example.Balenz.article.external.prompt.FrameTypeClassifyPrompt;
+import com.example.Balenz.article.external.prompt.KeywordPrompt;
+import com.example.Balenz.article.external.prompt.SummaryPrompt;
+import com.example.Balenz.article.service.AdminArticleService;
+import com.example.Balenz.global.exception.BaseException;
+import com.example.Balenz.global.exception.ErrorCode;
+import com.example.Balenz.internal.dto.TestResponseDto;
+import com.example.Balenz.internal.entity.TestArticle;
+import com.example.Balenz.internal.repository.TestArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TestService {
+
+    private final TestArticleRepository testArticleRepository;
+    private final ClaudeApiClient claudeApiClient;
+    private final AdminArticleService adminArticleService;
+
+    public TestResponseDto testPrompt(Long articleId) {
+        TestArticle testArticle = testArticleRepository.findById(articleId)
+                .orElseThrow(() -> new BaseException(ErrorCode.ARTICLE_NOT_FOUND, "해당 id의 테스트 기사를 찾을 수 없습니다."));
+
+        String title = testArticle.getTitle();
+        String content = testArticle.getContent();
+
+        // 키워드 추출
+        KeywordExtractDto keywordExtractDto = claudeApiClient.getResponse(
+                KeywordPrompt.create(title, content, List.of()),
+                300L,
+                KeywordExtractDto.class
+        );
+
+        // 기사 요약
+        SummaryDto summaryDto = claudeApiClient.getResponse(
+                SummaryPrompt.create(title, content),
+                1024L,
+                SummaryDto.class
+        );
+
+        String summary = summaryDto.summary();
+
+        // 이념 분류 가능 여부 판별
+        FrameTypeClassifiableDto frameTypeClassifiableDto = claudeApiClient.getResponse(
+                FrameTypeClassifiablePrompt.create(content),
+                300L,
+                FrameTypeClassifiableDto.class
+        );
+
+        boolean isClassifiable = frameTypeClassifiableDto.isClassifiable();
+
+        if (!isClassifiable) {
+            return TestResponseDto.builder()
+                    .keyword(keywordExtractDto.keyword())
+                    .summary(summary)
+                    .isClassifiable(false)
+                    .frameType(FrameType.UNKNOWN).build();
+
+        }
+
+        FrameTypeClassifyDto frameTypeClassifyDto = claudeApiClient.getResponse(
+                FrameTypeClassifyPrompt.create(content),
+                1024L,
+                FrameTypeClassifyDto.class
+        );
+
+        return TestResponseDto.builder()
+                .keyword(keywordExtractDto.keyword())
+                .summary(summary)
+                .isClassifiable(true)
+                .frameType(adminArticleService.toFrameType(frameTypeClassifyDto.ideology())).build();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: ${PORT:8080}
+
 spring:
   datasource:
     url: ${DATABASE_URL}


### PR DESCRIPTION
## ✅ 관련 이슈
closed #46 

## ✨ 작업 내용
별도의 API 테스트 도구를 설치하지 않아도 테스트 API를 쉽게 확인하고 실행할 수 있도록 Swagger 문서화를 추가했습니다.

### 외부 API로부터 테스트 기사 저장 기능 구현
- 외부 뉴스 API를 페이지 단위로 호출하여 테스트용 기사 데이터를 저장하도록 구현했습니다.
- 저장 대상에서 제외할 카테고리를 필터링하도록 처리했습니다.
- 외부 API 응답이 없거나 호출 중 오류가 발생하면 요청을 중단하고, 그전까지 정상적으로 저장된 기사 수를 반환하도록 구현했습니다.
- 테스트 기사 저장 API는 관리자만 호출할 수 있도록 설정했습니다.
#### [트러블슈팅] 외부 API 응답 중 EOF 오류
[문제] 외부 API가 JSON 응답을 모두 전송한 뒤 연결을 정상적으로 종료하지 않아, 응답 본문이 존재함에도 EOF 관련 예외가 발생하는 문제가 있었습니다.
[해결]
- RestTemplate.execute()를 사용해 응답 스트림을 직접 읽도록 변경
- 응답 스트림 처리 중 EOF가 발생하더라도, 수신된 데이터가 완전한 JSON이면 정상 응답으로 복구
- 복구할 수 없는 응답인 경우 해당 페이지부터 수집을 중단하고, 이전 페이지까지 저장된 데이터 수를 반환

### 테스트 기사 데이터 조회 기능 구현
- DB에 저장된 테스트 기사 데이터를 페이지 단위로 조회할 수 있도록 구현했습니다.
page, size 쿼리 파라미터를 통해 조회 범위를 지정할 수 있습니다.
- 응답에는 테스트 기사의 id, title, content가 포함됩니다.

### 프롬프트 테스트용 API 구현
- 테스트 기사 데이터 조회 시 조회한 id를 통해 키워드 추출 / 요약 / 이념 분류 가능 여부 / 이념 분류 프롬프트 테스트가 가능하도록 구현했습니다.
- id를 전달받아 테스트 기사를 조회하고, Claude API에 다음 요청을 순차적으로 전송합니다.
```
1. 키워드 추출
2. 기사 요약
3. 이념 분류 가능 여부 판단
4. 분류 가능한 경우 이념 유형 분류
```
- 존재하지 않는 기사 ID가 전달되면 ARTICLE_NOT_FOUND 오류를 반환합니다.



## 📸 스크린샷


## 🗨️ 참고 사항
노션 API 명세서의 '프롬프트 테스트 방법'에 테스트 방법 정리해두었습니다!