### PR TITLE
[Fix] Render 무료 인스턴스 메모리 사용량 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY --from=builder /app/build/libs/app.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=55.0", "-XX:InitialRAMPercentage=20.0", "-XX:+UseSerialGC", "-XX:+ExitOnOutOfMemoryError", "-jar", "app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,14 @@ spring:
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: ${DB_MAX_POOL_SIZE:5}
+      minimum-idle: ${DB_MIN_IDLE:1}
+      idle-timeout: 300000
+      max-lifetime: 1200000
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## ✅ 관련 이슈
#46 

## ✨ 작업 내용
Render 무료 인스턴스에서 서버가 메모리 제한에 도달해 반복 재시작되는 문제를 완화했습니다.
기존 서버는 실행 중 메모리 사용량이 약 522MB까지 증가하면서 제한 (512MB)에 근접했고, Spring Boot 인스턴스가 정상 기동하지 못한 채 반복 재시작되어, 메모리 사용량을 줄이기 위한 다음 설정을 적용했습니다.

#### JVM 메모리 최적화
- JVM 최대 메모리를 컨테이너 메모리의 55%로 제한
- 초기 메모리를 20%로 제한
- 저사양 환경에 적합한 Serial GC 적용
- OOM 발생 시 프로세스가 명확하게 종료되도록 설정

#### 데이터베이스 연결 최적화
- HikariCP 최대 커넥션 수를 5개로 제한
- 최소 유휴 커넥션 수를 1개로 제한
- 유휴 시간 및 커넥션 수명 설정
- JPA Open Session in View 비활성화

## 📸 스크린샷


## 🗨️ 참고 사항
